### PR TITLE
Fix mysql import from `varchar` to `text`

### DIFF
--- a/pages/docs/column-types/mysql.mdx
+++ b/pages/docs/column-types/mysql.mdx
@@ -318,7 +318,7 @@ CREATE TABLE `table` (
 
 <Section>
 ```typescript
-import { varchar, mysqlTable } from "drizzle-orm/mysql-core";
+import { text, mysqlTable } from "drizzle-orm/mysql-core";
 
 const table = mysqlTable('table', {
 	text: text('text'),


### PR DESCRIPTION
Fixed wrong import in [here](https://orm.drizzle.team/docs/column-types/mysql)