### PR TITLE
Grammar error in documentation: MySQL2 database connection

### DIFF
--- a/pages/docs/installation-and-db-connection/mysql/mysql2.mdx
+++ b/pages/docs/installation-and-db-connection/mysql/mysql2.mdx
@@ -28,7 +28,7 @@ Drizzle ORM natively supports `mysql2` with `drizzle-orm/mysql2` package
 </Tabs>
 
 There're two ways you can connect to the MySQL with `mysql2` driver - it's either single `client` connection or a `pool`.
-For the built in `migrate` function with DDL migrations we and drivers are strongly encourage you to use single `client` connection.  
+For the built in `migrate` function with DDL migrations we and drivers strongly encourage you to use single `client` connection.  
 For querying purposes feel free to use either `client` or `pool` based on your business demands.
 
 <Tabs items={['Client connection', 'Pool connection']}>


### PR DESCRIPTION
FIXED:
- Removed "are" from mysql2 documentation page to fix grammar error