### PR TITLE
Usage error in documentation: "According to" instead of "Due to"

### DIFF
--- a/pages/docs/installation-and-db-connection/mysql/mysql2.mdx
+++ b/pages/docs/installation-and-db-connection/mysql/mysql2.mdx
@@ -1,7 +1,7 @@
 import { Tab, Tabs } from "nextra-theme-docs";
 
 ## Node MySQL 2 
-Due to their [official website](https://github.com/sidorares/node-mysql2), 
+According to their [official website](https://github.com/sidorares/node-mysql2), 
 `mysql2` is a MySQL client for Node.js with focus on performance.  
 
 Drizzle ORM natively supports `mysql2` with `drizzle-orm/mysql2` package

--- a/pages/docs/installation-and-db-connection/mysql/planetscale.mdx
+++ b/pages/docs/installation-and-db-connection/mysql/planetscale.mdx
@@ -1,7 +1,7 @@
 import { Tab, Tabs } from "nextra-theme-docs";
 
 ## PlanetScale
-Due to their [official website](https://planetscale.com/), 
+According to their [official website](https://planetscale.com/), 
 PlanetScale is the world's most advanced serverless MySQL platform
 
 With Drizzle ORM you can access PlanetScale over http

--- a/pages/docs/installation-and-db-connection/postgresql/neon.mdx
+++ b/pages/docs/installation-and-db-connection/postgresql/neon.mdx
@@ -1,7 +1,7 @@
 import { Tab, Tabs } from "nextra-theme-docs";
 
 ## Neon 
-Due to their [official website](https://neon.tech), Neon database is a multi-cloud fully managed Postgres. 
+According to their [official website](https://neon.tech), Neon database is a multi-cloud fully managed Postgres. 
   
 Drizzle ORM natively supports both [Neon Serverless](https://github.com/neondatabase/serverless) 
 driver with `drizzle-orm/neon-serverless` package and [`postgres`](./postgresjs) or [`pg`](./node-postgres) 
@@ -45,5 +45,5 @@ export default {
 }
 ```
 
-If you're about to use Neon from a serverfull environments, due to their [official nodejs docs](https://neon.tech/docs/guides/node) 
+If you're about to use Neon from a serverfull environments, according to their [official nodejs docs](https://neon.tech/docs/guides/node) 
 you should just use PostgresJS driver - see [docs](./postgresjs).

--- a/pages/docs/installation-and-db-connection/postgresql/node-postgres.mdx
+++ b/pages/docs/installation-and-db-connection/postgresql/node-postgres.mdx
@@ -1,7 +1,7 @@
 import { Tab, Tabs } from "nextra-theme-docs";
 
 ## node-postgres
-Due to their [official website](https://node-postgres.com/), node-postgres is a collection 
+According to their [official website](https://node-postgres.com/), node-postgres is a collection 
 of node.js modules for interfacing with your PostgreSQL database  
 
 Drizzle ORM natively supports `pg` with `drizzle-orm/pg` package

--- a/pages/docs/installation-and-db-connection/postgresql/postgresjs.mdx
+++ b/pages/docs/installation-and-db-connection/postgresql/postgresjs.mdx
@@ -1,7 +1,7 @@
 import { Tab, Tabs } from "nextra-theme-docs";
 
 ## PostgresJS
-Due to their [official website](https://github.com/porsager/postgres), 
+According to their [official website](https://github.com/porsager/postgres), 
 PostgresJS is the fastest full featured PostgreSQL client for Node.js and Deno  
 
 Drizzle ORM natively supports `postgresjs` driver with `drizzle-orm/postgres-js` package

--- a/pages/docs/installation-and-db-connection/sqlite/better-sqlite3.mdx
+++ b/pages/docs/installation-and-db-connection/sqlite/better-sqlite3.mdx
@@ -1,7 +1,7 @@
 import { Tab, Tabs } from 'nextra-theme-docs';
 
 ## BetterSqlite3
-Due to their [official docs](https://github.com/WiseLibs/better-sqlite3), 
+According to their [official docs](https://github.com/WiseLibs/better-sqlite3), 
 BetterSqlite3 is the fastest and simplest library for SQLite3 in Node.js.
 
 Drizzle ORM embraces SQL dialects and dialect specific drivers and syntax and unlike any other ORM, 

--- a/pages/docs/installation-and-db-connection/sqlite/bun.mdx
+++ b/pages/docs/installation-and-db-connection/sqlite/bun.mdx
@@ -1,7 +1,7 @@
 import { Tab, Tabs } from 'nextra-theme-docs';
 
 ## Bun SQLite
-Due to their [official website](https://bun.sh/), Bun is a fast all-in-one JavaScript runtime  
+According to their [official website](https://bun.sh/), Bun is a fast all-in-one JavaScript runtime  
 
 Drizzle ORM natively supports [`bun:sqlite`](https://bun.sh/docs/api/sqlite) module and it's crazy fast 🚀  
 We embraces SQL dialects and dialect specific drivers and syntax and unlike any other ORM, 

--- a/pages/docs/installation-and-db-connection/sqlite/d1.mdx
+++ b/pages/docs/installation-and-db-connection/sqlite/d1.mdx
@@ -1,7 +1,7 @@
 import { Tab, Tabs } from 'nextra-theme-docs';
 
 ## Cloudflare D1
-Due to their [official website](https://developers.cloudflare.com/d1/), 
+According to their [official website](https://developers.cloudflare.com/d1/), 
 D1 is Cloudflare's first queryable relational database.  
   
 Drizzle ORM fully supports D1 database and Cloudflare Workers environment, 

--- a/pages/docs/installation-and-db-connection/sqlite/turso.mdx
+++ b/pages/docs/installation-and-db-connection/sqlite/turso.mdx
@@ -1,7 +1,7 @@
 import { Tab, Tabs } from 'nextra-theme-docs';
 
 ## Turso
-Due to their [official website](https://turso.tech/), 
+According to their [official website](https://turso.tech/), 
 Turso is a [libSQL](https://github.com/libsql/libsql) powered edge SQLite database as a service
   
 Drizzle ORM natively supports libSQL driver, 

--- a/pages/docs/views.mdx
+++ b/pages/docs/views.mdx
@@ -243,7 +243,7 @@ export const trimmedUser = pgMaterializedView("trimmed_user", {
 
 ### Materialized views
 `✓ PostgreSQL` `✕ MySQL` `✕ SQLite`  
-Due to their official docs, PostgreSQL has [`regular`](https://www.postgresql.org/docs/current/sql-createview.html) 
+According to their official docs, PostgreSQL has [`regular`](https://www.postgresql.org/docs/current/sql-createview.html) 
 and [`materialized`](https://www.postgresql.org/docs/current/sql-creatematerializedview.html)  
   
 Materialized views in PostgreSQL use the rule system like views do, but persist the results in a table-like form  


### PR DESCRIPTION
FIXED:
- Changed "Due to" to "According to"