### PR TITLE
Add note about PlanetScale SSL connection strings

### DIFF
--- a/pages/kit-docs/conf.mdx
+++ b/pages/kit-docs/conf.mdx
@@ -195,6 +195,10 @@ export default {
   connectionString: "postgresql://postgres:password@host:port/db",
 } satisfies Config;
 ```
+<Callout type="info" emoji="ℹ️">
+When using the PlanetScale driver, your connection string must end with `?ssl={"rejectUnauthorized":true}` instead of `?sslaccept=strict`.
+</Callout>
+
 </Tab>
 <Tab>
 ```ts {6-10}


### PR DESCRIPTION
PlanetScale gives you connection strings with `?sslaccept=strict`, which doesn't work, whereas `?ssl={"rejectUnauthorized":true}` does work.

Seen this pop up a few times so figured it was worth adding now that push is out of preview.