### PR TITLE
docs: fix infer model type import, unify mysql pool connection

### DIFF
--- a/pages/docs/installation-and-db-connection/mysql/mysql2.mdx
+++ b/pages/docs/installation-and-db-connection/mysql/mysql2.mdx
@@ -41,7 +41,7 @@ For querying purposes feel free to use either `client` or `pool` based on your b
     host: "host",
     user: "user",
     database: "database",
-    ...
+    // ...
   });
 
   const db = drizzle(connection);
@@ -53,14 +53,14 @@ For querying purposes feel free to use either `client` or `pool` based on your b
   import { drizzle } from "drizzle-orm/mysql2";
   import mysql from "mysql2/promise";
 
-  const poolConnection = mysql.createPool({
+  const pool = mysql.createPool({
     host: "host",
     user: "user",
     database: "database",
-    ...
+    // ...
   });
 
-  const db = drizzle(connection);
+  const db = drizzle(pool);
   ```
   </Tab>
 </Tabs>

--- a/pages/docs/migrations.mdx
+++ b/pages/docs/migrations.mdx
@@ -57,16 +57,16 @@ import { migrate } from 'drizzle-orm/mysql2/migrator';
 import mysql from 'mysql2/promise';
 
 // create the connection
-const poolConnection = mysql.createPool({
+const pool = mysql.createPool({
   host: 'localhost',
   user: 'root',
   database: 'test',
   multipleStatements: true,
 });
 
-const db = drizzle(poolConnection);
+const db = drizzle(pool);
 
 // this will automatically run needed migrations on the database
-await migrate(db, { migrationsFolder: './drizzle' });
+await migrate(db, { migrationsFolder: 'drizzle' });
 ```
 

--- a/pages/docs/sql-schema-declaration.mdx
+++ b/pages/docs/sql-schema-declaration.mdx
@@ -130,13 +130,13 @@ Please pay attention to `export` keyword, they are mandatory if you'll be using 
   // ...
 
   // init mysql2 Pool or Client
-  const connection = mysql.createPool({
+  const pool = mysql.createPool({
       host:'localhost', 
       user: 'root',
       database: 'test'
   });
 
-  export const db = drizzle(connection);
+  export const db = drizzle(pool);
 
   const result: User[] = await db.select().from(users);
 

--- a/pages/docs/sql-schema-declaration.mdx
+++ b/pages/docs/sql-schema-declaration.mdx
@@ -2,7 +2,7 @@ import { Tab, Tabs } from 'nextra-theme-docs';
 
 # SQL schema declaration
 
-You declare SQL schema in TypeScript in either one `schema.ts` file 
+You declare SQL schema in TypeScript in either one `schema.ts` file
 or you can group them logically in multiple logically grouped files, whichever you prefer, all the freedom!
 
 ```plaintext
@@ -25,6 +25,7 @@ or you can group them logically in multiple logically grouped files, whichever y
           ├ 📜 enums.ts
           └ 📜 etc.ts
 ```
+
 ```plaintext
 📦 <project root>
  └ 📂 src
@@ -33,12 +34,13 @@ or you can group them logically in multiple logically grouped files, whichever y
     │  └ 📜 handler.ts
     ├ 📂 get-city
     │  ├ 📜 city.ts
-    │  └ 📜 handler.ts    
+    │  └ 📜 handler.ts
     ├  ...
 ```
 
 You can declare tables, indexes and constraints, foreign keys and enums.  
 Please pay attention to `export` keyword, they are mandatory if you'll be using [drizzle-kit SQL migrations generator](#migrations)
+
 <Tabs items={['PostgreSQL', 'MySQL', 'SQLite']}>
   <Tab>
   ```typescript copy
@@ -66,7 +68,8 @@ Please pay attention to `export` keyword, they are mandatory if you'll be using 
 
   Database and table explicit entity types:
   ```typescript copy
-  import { pgTable, InferModel, serial, text, varchar } from 'drizzle-orm/pg-core';
+  import type { InferModel } from 'drizzle-orm';
+  import { pgTable, serial, text, varchar } from 'drizzle-orm/pg-core';
   import { drizzle, NodePgDatabase } from 'drizzle-orm/node-postgres';
 
   const users = pgTable('users', {
@@ -77,7 +80,7 @@ Please pay attention to `export` keyword, they are mandatory if you'll be using 
 
   export type User = InferModel<typeof users>; // return type when queried
   export type NewUser = InferModel<typeof users, 'insert'>; // insert type
-  ...
+  // ...
 
   const db: NodePgDatabase = drizzle(...);
 
@@ -110,9 +113,11 @@ Please pay attention to `export` keyword, they are mandatory if you'll be using 
 
   Database and table explicit entity types:  
   ```typescript copy
-  import { InferModel, MySqlDatabase, MySqlRawQueryResult, mysqlTable, serial, text, varchar } from 'drizzle-orm/mysql-core';
-  import mysql from 'mysql2/promise';
+  import type { InferModel } from 'drizzle-orm';
+  import { mysqlTable, serial, text, varchar } from 'drizzle-orm/mysql-core';
+  import type { MySqlRawQueryResult } from 'drizzle-orm/mysql2';
   import { drizzle } from 'drizzle-orm/mysql2';
+  import mysql from 'mysql2/promise';
 
   const users = mysqlTable('users', {
     id: serial('id').primaryKey(),
@@ -122,16 +127,16 @@ Please pay attention to `export` keyword, they are mandatory if you'll be using 
 
   export type User = InferModel<typeof users>; // return type when queried
   export type NewUser = InferModel<typeof users, 'insert'>; // insert type
-  ...
+  // ...
 
   // init mysql2 Pool or Client
-  const poolConnection = mysql.createPool({
+  const connection = mysql.createPool({
       host:'localhost', 
       user: 'root',
       database: 'test'
   });
 
-  export const db: MySqlDatabase = drizzle(poolConnection);
+  export const db = drizzle(connection);
 
   const result: User[] = await db.select().from(users);
 
@@ -172,7 +177,8 @@ Please pay attention to `export` keyword, they are mandatory if you'll be using 
 
   export type User = InferModel<typeof users> // return type when queried
   export type InsertUser = InferModel<typeof users, 'insert'> // insert type
-  ...
+  // ...
+
   import { drizzle, BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
   import Database from 'better-sqlite3';
 
@@ -187,4 +193,3 @@ Please pay attention to `export` keyword, they are mandatory if you'll be using 
   ```
   </Tab>
 </Tabs>
-


### PR DESCRIPTION
Referenced the [Node MySQL 2] documentation and used the `pool` variable name.

[Node MySQL 2]: https://github.com/sidorares/node-mysql2#readme

```javascript
async function main() {
  // get the client
  const mysql = require('mysql2');
  // create the pool
  const pool = mysql.createPool({host:'localhost', user: 'root', database: 'test'});
  // ...
```

```javascript
// get the client
const mysql = require('mysql2');

// Create the connection pool. The pool-specific settings are the defaults
const pool = mysql.createPool({
  host: 'localhost',
  user: 'root',
  database: 'test',
  waitForConnections: true,
  connectionLimit: 10,
  maxIdle: 10, // max idle connections, the default value is the same as `connectionLimit`
  idleTimeout: 60000, // idle connections timeout, in milliseconds, the default value 60000
  queueLimit: 0,
  enableKeepAlive: true,
  keepAliveInitialDelay: 0
});
```
