### PR TITLE
Corrected import path of 'InferModel' in the schema declaration page

### DIFF
--- a/pages/docs/sql-schema-declaration.mdx
+++ b/pages/docs/sql-schema-declaration.mdx
@@ -66,7 +66,8 @@ Please pay attention to `export` keyword, they are mandatory if you'll be using 
 
   Database and table explicit entity types:
   ```typescript copy
-  import { pgTable, InferModel, serial, text, varchar } from 'drizzle-orm/pg-core';
+  import { pgTable, serial, text, varchar } from 'drizzle-orm/pg-core';
+  import { InferModel } from 'drizzle-orm';
   import { drizzle, NodePgDatabase } from 'drizzle-orm/node-postgres';
 
   const users = pgTable('users', {
@@ -110,7 +111,8 @@ Please pay attention to `export` keyword, they are mandatory if you'll be using 
 
   Database and table explicit entity types:  
   ```typescript copy
-  import { InferModel, MySqlDatabase, MySqlRawQueryResult, mysqlTable, serial, text, varchar } from 'drizzle-orm/mysql-core';
+  import { MySqlDatabase, MySqlRawQueryResult, mysqlTable, serial, text, varchar } from 'drizzle-orm/mysql-core';
+  import { InferModel } from 'drizzle-orm';
   import mysql from 'mysql2/promise';
   import { drizzle } from 'drizzle-orm/mysql2';
 


### PR DESCRIPTION
The docs mentioned 
```ts
import { InferModel } from 'drizzle-core/pg-core';
```
which was incorrect. 

It has been corrected to
```ts
import { InferModel } from 'drizzle-core';
```