### PR TITLE
Use environment variables for sensitive data in drizzle kit config docs

### DIFF
--- a/pages/kit-docs/conf.mdx
+++ b/pages/kit-docs/conf.mdx
@@ -208,7 +208,7 @@ export default {
   schema: "./src/schema/*",
   out: "./drizzle",
   user: "postgres",
-  password: process.env.DATABASE_PW,
+  password: process.env.DATABASE_PASSWORD,
   host: "127.0.0.1",
   port: 5432,
   db: "db",

--- a/pages/kit-docs/conf.mdx
+++ b/pages/kit-docs/conf.mdx
@@ -188,23 +188,27 @@ We mirror connection params of database drivers
 <Tab>
 ```ts {6}
 import type { Config } from "drizzle-kit";
+import * as dotenv from "dotenv";
+dotenv.config();
 
 export default {
   schema: "./src/schema/*",
   out: "./drizzle",
-  connectionString: "postgresql://postgres:password@host:port/db",
+  connectionString: process.env.DATABASE_URL,
 } satisfies Config;
 ```
 </Tab>
 <Tab>
 ```ts {6-10}
 import type { Config } from "drizzle-kit";
+import * as dotenv from "dotenv";
+dotenv.config();
 
 export default {
   schema: "./src/schema/*",
   out: "./drizzle",
   user: "postgres",
-  password: "password",
+  password: process.env.DATABASE_PW,
   host: "127.0.0.1",
   port: 5432,
   db: "db",
@@ -232,11 +236,13 @@ const users = pgTable('users', {
 ```
 ```ts {7}
 import type { Config } from "drizzle-kit";
+import * as dotenv from "dotenv";
+dotenv.config();
 
 export default {
   schema: "./src/schema/*",
   out: "./drizzle",
-  connectionString: "DATABASE_URL",
+  connectionString: process.env.DATABASE_URL,
   tablesFilter: ["project1_*"],
 } satisfies Config;
 ```


### PR DESCRIPTION
The docs currently suggest to put sensitive data into source control which is usually not desired.