### PR TITLE
Fix type import in JS configuration

### DIFF
--- a/pages/kit-docs/overview.mdx
+++ b/pages/kit-docs/overview.mdx
@@ -168,8 +168,6 @@ export default {
 </CodeTab>
 <CodeTab>
 ```js
-import type { Config } from "drizzle-kit";
-
 /** @type { import("drizzle-kit").Config } */
 export default {
   schema: "./schema.ts",


### PR DESCRIPTION
Removing a type import from the JS example for drizzle-kit config, since you cannot import types this way in JS (and it's also unused anyways)