### PR TITLE
docs: fix vercel/postgress links at vercel.mdx

### DIFF
--- a/pages/docs/installation-and-db-connection/postgresql/vercel.mdx
+++ b/pages/docs/installation-and-db-connection/postgresql/vercel.mdx
@@ -5,7 +5,7 @@ import { Tab, Tabs, Steps } from "nextra-theme-docs";
 According to their [official website](https://vercel.com/docs/storage/vercel-postgres),
 Vercel Postgres is a is a serverless SQL database designed to integrate with Vercel Functions.
 
-Drizzle ORM natively supports both [@vercel/postgres](https://github.com/neondatabase/serverless) serverless
+Drizzle ORM natively supports both [@vercel/postgres](https://vercel.com/docs/storage/vercel-postgres) serverless
 driver with `drizzle-orm/vercel-postgres` package and [`postgres`](./postgresjs) or [`pg`](./node-postgres)
 drivers to access Vercel Postgres through `postgesql://`
 
@@ -51,7 +51,7 @@ const result = await db.select().from(...);
 ```
 </Steps>
 
-With [@vercel/postgres](https://github.com/neondatabase/serverless) severless package
+With [@vercel/postgres](https://vercel.com/docs/storage/vercel-postgres) severless package
 you can access Vercel Postgres from either serverful or serverless environments with no TCP available,
 like Cloudflare Workers, through websockets.  
   


### PR DESCRIPTION
Updated the link to @vercel/postgress. Old link was linking to the https://github.com/neondatabase/serverless.