### PR TITLE
Mark ilike as not supported for mysql and sqlite

### DIFF
--- a/pages/docs/operators.mdx
+++ b/pages/docs/operators.mdx
@@ -358,7 +358,7 @@ SELECT * FROM table  WHERE table.column LIKE '%llo wor%'
 </Section>
 
 ### ilike
-`✓ PostgreSQL` `✓ MySQL` `✓ SQLite`  
+`✓ PostgreSQL` `✕ MySQL` `✕ SQLite`  
   
 Value is like some other value, case insensitive
 <Section>


### PR DESCRIPTION
As far as I'm aware ilike is a postgres exclusive so it should not be marked as supported in the docs for mysql and sqlite.

Related discord thread - https://discord.com/channels/1043890932593987624/1096009424092528650