### PR TITLE
docs: updated varchar length

### DIFF
--- a/pages/docs/column-types/pg.mdx
+++ b/pages/docs/column-types/pg.mdx
@@ -1,12 +1,12 @@
 import Section from "../../../components/Section/Section";
 
-  
+
 ### PostgreSQL column types
 We have native support for all of them, yet if that's not enough for you - feel free to create [custom types](../custom-types).
 
 #### integer
-`integer` `int` `int4`  
-Signed 4-byte integer     
+`integer` `int` `int4`
+Signed 4-byte integer
 If you need `integer autoincrement` - please refer to [serial](#serial)
 
 <Section>
@@ -47,8 +47,8 @@ CREATE TABLE IF NOT EXISTS "table" (
 </Section>
 
 #### smallint
-`smallint` `int2`  
-Small-range signed 2-byte integer   
+`smallint` `int2`
+Small-range signed 2-byte integer
 If you need `smallint autoincrement` - please refer to [smallserial](#smallserial)
 <Section>
 ```typescript
@@ -86,11 +86,11 @@ CREATE TABLE IF NOT EXISTS "table" (
 </Section>
 
 #### bigint
-`bigint` `int8`  
-Signed 8-byte integer  
+`bigint` `int8`
+Signed 8-byte integer
 If you need `bigint autoincrement` - please refer to [bigserial](#bigserial)
 
-If you're expecting values above 2^31 but below 2^53, you can utilise `mode: 'number'` and deal with javascript number as opposed to bigint  
+If you're expecting values above 2^31 but below 2^53, you can utilise `mode: 'number'` and deal with javascript number as opposed to bigint
 <Section>
 ```typescript
 import { bigint, pgTable } from "drizzle-orm/pg-core";
@@ -133,9 +133,9 @@ CREATE TABLE IF NOT EXISTS "table" (
 </Section>
 
 #### serial
-`serial` `serial4`  
-Auto incrementing 4-bytes integer, notational convenience for creating unique identifier columns (similar to the `AUTO_INCREMENT` property supported by some other databases).  
-Official PostrgreSQL [docs](https://www.postgresql.org/docs/current/datatype-numeric.html#DATATYPE-SERIAL)  
+`serial` `serial4`
+Auto incrementing 4-bytes integer, notational convenience for creating unique identifier columns (similar to the `AUTO_INCREMENT` property supported by some other databases).
+Official PostrgreSQL [docs](https://www.postgresql.org/docs/current/datatype-numeric.html#DATATYPE-SERIAL)
 <Section>
 ```typescript
 import { serial, pgTable } from "drizzle-orm/pg-core";
@@ -153,9 +153,9 @@ CREATE TABLE IF NOT EXISTS "table" (
 </Section>
 
 #### smallserial
-`smallserial` `serial2`  
-Auto incrementing 2-bytes integer, notational convenience for creating unique identifier columns (similar to the `AUTO_INCREMENT` property supported by some other databases).  
-Official PostrgreSQL [docs](https://www.postgresql.org/docs/current/datatype-numeric.html#DATATYPE-SERIAL)  
+`smallserial` `serial2`
+Auto incrementing 2-bytes integer, notational convenience for creating unique identifier columns (similar to the `AUTO_INCREMENT` property supported by some other databases).
+Official PostrgreSQL [docs](https://www.postgresql.org/docs/current/datatype-numeric.html#DATATYPE-SERIAL)
 <Section>
 ```typescript
 import { smallserial, pgTable } from "drizzle-orm/pg-core";
@@ -173,11 +173,11 @@ CREATE TABLE IF NOT EXISTS "table" (
 </Section>
 
 #### bigserial
-`bigserial` `serial8`  
-Auto incrementing 8-bytes integer, notational convenience for creating unique identifier columns (similar to the `AUTO_INCREMENT` property supported by some other databases).  
-Official PostrgreSQL [docs](https://www.postgresql.org/docs/current/datatype-numeric.html#DATATYPE-SERIAL)  
+`bigserial` `serial8`
+Auto incrementing 8-bytes integer, notational convenience for creating unique identifier columns (similar to the `AUTO_INCREMENT` property supported by some other databases).
+Official PostrgreSQL [docs](https://www.postgresql.org/docs/current/datatype-numeric.html#DATATYPE-SERIAL)
 
-If you're expecting values above 2^31 but below 2^53, you can utilise `mode: 'number'` and deal with javascript number as opposed to bigint  
+If you're expecting values above 2^31 but below 2^53, you can utilise `mode: 'number'` and deal with javascript number as opposed to bigint
 <Section>
 ```typescript
 import { bigserial, pgTable } from "drizzle-orm/pg-core";
@@ -197,7 +197,7 @@ CREATE TABLE IF NOT EXISTS "table" (
 
 #### boolean
 PostgreSQL provides the standard SQL type boolean
-Official PostrgreSQL [docs](https://www.postgresql.org/docs/current/datatype-boolean.html)  
+Official PostrgreSQL [docs](https://www.postgresql.org/docs/current/datatype-boolean.html)
 
 <Section>
 ```typescript
@@ -217,10 +217,10 @@ CREATE TABLE IF NOT EXISTS "table" (
 </Section>
 
 #### text
-`text`  
-Variable-length(unlimited) character string  
-Official PostrgreSQL [docs](https://www.postgresql.org/docs/current/datatype-character.html)  
-  
+`text`
+Variable-length(unlimited) character string
+Official PostrgreSQL [docs](https://www.postgresql.org/docs/current/datatype-character.html)
+
 You can define `{ enum: ["value1", "value2"] }` config to infer `insert` and `select` types, it **won't** check runtime values
 <Section>
 ```typescript
@@ -242,11 +242,11 @@ CREATE TABLE IF NOT EXISTS "table" (
 </Section>
 
 #### varchar
-`character varying(n)` `varchar(n)`  
-Variable-length character string, can store strings up to **`n`** characters(not bytes)  
-Official PostrgreSQL [docs](https://www.postgresql.org/docs/current/datatype-character.html)  
+`character varying(n)` `varchar(n)`
+Variable-length character string, can store strings up to **`n`** characters(not bytes)
+Official PostrgreSQL [docs](https://www.postgresql.org/docs/current/datatype-character.html)
 
-You can define `{ enum: ["value1", "value2"] }` config to infer `insert` and `select` types, it **won't** check runtime values  
+You can define `{ enum: ["value1", "value2"] }` config to infer `insert` and `select` types, it **won't** check runtime values
 `length` parameter is optional according to PostgreSQL docs
 <Section>
 ```typescript
@@ -254,7 +254,7 @@ import { varchar, pgTable } from "drizzle-orm/pg-core";
 
 export const table = pgTable('table', {
   varchar1: varchar('varchar1'),
-  varchar1: varchar('varchar2', { length: 256 }),
+  varchar1: varchar('varchar2', { length: 255 }),
 });
 
 // will be inferred as text: "value1" | "value2" | null
@@ -264,17 +264,17 @@ varchar: varchar('varchar', { enum: ["value1", "value2"] }),
 ```sql
 CREATE TABLE IF NOT EXISTS "table" (
 	"varchar1" varchar,
-	"varchar2" varchar(256),
+	"varchar2" varchar(255),
 );
 ```
 </Section>
 
 #### char
-`character(n)` `char(n)`  
-Fixed-length, blank padded character string, can store strings up to **`n`** characters(not bytes)  
-Official PostrgreSQL [docs](https://www.postgresql.org/docs/current/datatype-character.html)  
+`character(n)` `char(n)`
+Fixed-length, blank padded character string, can store strings up to **`n`** characters(not bytes)
+Official PostrgreSQL [docs](https://www.postgresql.org/docs/current/datatype-character.html)
 
-You can define `{ enum: ["value1", "value2"] }` config to infer `insert` and `select` types, it **won't** check runtime values  
+You can define `{ enum: ["value1", "value2"] }` config to infer `insert` and `select` types, it **won't** check runtime values
 `length` parameter is optional according to PostgreSQL docs
 <Section>
 ```typescript
@@ -282,7 +282,7 @@ import { char, pgTable } from "drizzle-orm/pg-core";
 
 export const table = pgTable('table', {
   char1: char('char1'),
-  char2: char('char2', { length: 256 }),
+  char2: char('char2', { length: 255 }),
 });
 
 // will be inferred as text: "value1" | "value2" | null
@@ -292,15 +292,15 @@ char: char('char', { enum: ["value1", "value2"] }),
 ```sql
 CREATE TABLE IF NOT EXISTS "table" (
 	"char1" char,
-	"char2" char(256),
+	"char2" char(255),
 );
 ```
 </Section>
 
 #### numeric
-`numeric` `decimal`  
-Exact numeric of selectable precision. Can store numbers with a very large number of digits, up to 131072 digits before the decimal point and up to 16383 digits after the decimal point  
-Official PostrgreSQL [docs](https://www.postgresql.org/docs/current/datatype-numeric.html#DATATYPE-NUMERIC-DECIMAL)  
+`numeric` `decimal`
+Exact numeric of selectable precision. Can store numbers with a very large number of digits, up to 131072 digits before the decimal point and up to 16383 digits after the decimal point
+Official PostrgreSQL [docs](https://www.postgresql.org/docs/current/datatype-numeric.html#DATATYPE-NUMERIC-DECIMAL)
 <Section>
 ```typescript
 import { numeric, pgTable } from "drizzle-orm/pg-core";
@@ -325,14 +325,14 @@ CREATE TABLE IF NOT EXISTS "table" (
 Is an alias of [numeric](#numeric)
 
 #### real
-`real` `float4`  
-Single precision floating-point number (4 bytes)  
-Official PostrgreSQL [docs](https://www.postgresql.org/docs/current/datatype-numeric.html)  
+`real` `float4`
+Single precision floating-point number (4 bytes)
+Official PostrgreSQL [docs](https://www.postgresql.org/docs/current/datatype-numeric.html)
 
 <Section>
 ```typescript
 import { sql } from "drizzle-orm";
-import { real, pgTable } from "drizzle-orm/pg-core";  
+import { real, pgTable } from "drizzle-orm/pg-core";
 
 const table = pgTable('table', {
 	real1: real('real1'),
@@ -351,9 +351,9 @@ CREATE TABLE IF NOT EXISTS "table" (
 </Section>
 
 #### double precision
-`double precision` `float8`  
-Double precision floating-point number (8 bytes)  
-Official PostrgreSQL [docs](https://www.postgresql.org/docs/current/datatype-numeric.html)  
+`double precision` `float8`
+Double precision floating-point number (8 bytes)
+Official PostrgreSQL [docs](https://www.postgresql.org/docs/current/datatype-numeric.html)
 
 <Section>
 ```typescript
@@ -377,8 +377,8 @@ CREATE TABLE IF NOT EXISTS "table" (
 </Section>
 
 #### json
-`json`  
-Textual JSON data, as specified in [RFC 7159](https://tools.ietf.org/html/rfc7159)  
+`json`
+Textual JSON data, as specified in [RFC 7159](https://tools.ietf.org/html/rfc7159)
 Official PostrgreSQL [docs](https://www.postgresql.org/docs/current/datatype-json.html)
 <Section>
 ```typescript
@@ -400,8 +400,8 @@ CREATE TABLE IF NOT EXISTS "table" (
 );
 ```
 </Section>
-  
-You can specify `.$type<..>()` for json object inference, it **won't** check runtime values. 
+
+You can specify `.$type<..>()` for json object inference, it **won't** check runtime values.
 It provides compile time protection for default values, insert and select schemas.
 ```typescript
 // will be infered as { foo: string }
@@ -415,8 +415,8 @@ json: json('json').$type<string[]>().default({});
 ```
 
 #### jsonb
-`jsonb`  
-Binary JSON data, decomposed  
+`jsonb`
+Binary JSON data, decomposed
 Official PostrgreSQL [docs](https://www.postgresql.org/docs/current/datatype-json.html)
 <Section>
 ```typescript
@@ -437,7 +437,7 @@ CREATE TABLE IF NOT EXISTS "table" (
 ```
 </Section>
 
-You can specify `.$type<..>()` for json object inference, it **won't** check runtime values. 
+You can specify `.$type<..>()` for json object inference, it **won't** check runtime values.
 It provides compile time protection for default values, insert and select schemas.
 
 ```typescript
@@ -452,8 +452,8 @@ jsonb: jsonb('jsonb').$type<string[]>().default({});
 ```
 
 #### time
-`time` `timetz` `time with timezone` `time without timezone`  
-Time of day with or without time zone  
+`time` `timetz` `time with timezone` `time without timezone`
+Time of day with or without time zone
 PostgreSQL [docs](https://www.postgresql.org/docs/current/datatype-datetime.html)
 
 <Section>
@@ -479,9 +479,9 @@ CREATE TABLE IF NOT EXISTS "table" (
 </Section>
 
 #### timestamp
-`timestamp` `timestamptz` `timestamp with time zone` `timestamp without time zone`  
-Date and time with or without time zone  
-PostgreSQL [docs](https://www.postgresql.org/docs/current/datatype-datetime.html)  
+`timestamp` `timestamptz` `timestamp with time zone` `timestamp without time zone`
+Date and time with or without time zone
+PostgreSQL [docs](https://www.postgresql.org/docs/current/datatype-datetime.html)
 <Section>
 ```typescript
 import { sql } from "drizzle-orm";
@@ -514,9 +514,9 @@ timestamp: timestamp('timestamp', { mode: "string" }),
 ```
 
 #### date
-`date`  
-Calendar date (year, month, day)  
-PostgreSQL [docs](https://www.postgresql.org/docs/current/datatype-datetime.html) 
+`date`
+Calendar date (year, month, day)
+PostgreSQL [docs](https://www.postgresql.org/docs/current/datatype-datetime.html)
 <Section>
 ```typescript
 import { date, pgTable } from "drizzle-orm/pg-core";
@@ -541,9 +541,9 @@ date: date('date', { mode: "date" }),
 date: date('date', { mode: "string" }),
 ```
 #### interval
-`interval`  
-Time span  
-PostgreSQL [docs](https://www.postgresql.org/docs/current/datatype-datetime.html)  
+`interval`
+Time span
+PostgreSQL [docs](https://www.postgresql.org/docs/current/datatype-datetime.html)
 
 <Section>
 ```typescript
@@ -566,10 +566,10 @@ CREATE TABLE IF NOT EXISTS "table" (
 ```
 </Section>
 
-#### enum 
-`enum` `enumerated types`  
-Enumerated (enum) types are data types that comprise a static, ordered set of values. 
-They are equivalent to the enum types supported in a number of programming languages. 
+#### enum
+`enum` `enumerated types`
+Enumerated (enum) types are data types that comprise a static, ordered set of values.
+They are equivalent to the enum types supported in a number of programming languages.
 An example of an enum type might be the days of the week, or a set of status values for a piece of data.
 
 PostgreSQL [docs](https://www.postgresql.org/docs/current/datatype-enum.html)
@@ -649,7 +649,7 @@ CREATE TABLE IF NOT EXISTS "table" (
 
 
 #### Primary key
-A primary key constraint indicates that a column, or group of columns, can be used as a unique identifier for rows in the table. 
+A primary key constraint indicates that a column, or group of columns, can be used as a unique identifier for rows in the table.
 This requires that the values be both unique and not null.
 <Section>
 ```typescript

--- a/pages/docs/custom-types.mdx
+++ b/pages/docs/custom-types.mdx
@@ -202,7 +202,7 @@ const usersTable = mysqlTable('userstest', {
   </Tab>
 </Tabs>
 
-## TS-doc for type definitions 
+## TS-doc for type definitions
 
 You can check ts-doc for types and param definition
 
@@ -265,7 +265,7 @@ export interface CustomTypeParams<T extends CustomTypeValues> {
    * If database data type needs additional params you can use them from `config` param
    * @example
    * ```
-   * `varchar(256)`, `numeric(2,3)`
+   * `varchar(255)`, `numeric(2,3)`
    * ```
    *
    * To make `config` be of specific type please use config generic in {@link CustomTypeValues}

--- a/pages/docs/migrations.mdx
+++ b/pages/docs/migrations.mdx
@@ -1,11 +1,11 @@
 
 # Migrations
-The most important thing about Drizzle ORM is that you can use it as a source of truth for database schema.  
-[DrizzleKit](/kit-docs) - is a CLI companion for DrizzleORM, it lets generate SQL statements for schema creation and alternations 
-or apply changes directly to the database.  
-  
+The most important thing about Drizzle ORM is that you can use it as a source of truth for database schema.
+[DrizzleKit](/kit-docs) - is a CLI companion for DrizzleORM, it lets generate SQL statements for schema creation and alternations
+or apply changes directly to the database.
+
 See detailed [docs](/kit-docs) for extended examples and walk throughs
-  
+
 ## Quick start
 Declare your schema
 ```typescript copy filename="./src/schema.ts"
@@ -13,14 +13,14 @@ import { index, integer, mysqlTable, serial, varchar } from 'drizzle-orm/mysql-c
 
 export const users = mysqlTable('users', {
   id: serial('id').primaryKey(),
-  fullName: varchar('full_name', { length: 256 }),
+  fullName: varchar('full_name', { length: 255 }),
 }, (users) => ({
   nameIdx: index('name_idx').on(users.fullName),
 }));
 
 export const authOtps = mysqlTable('auth_otp', {
   id: serial('id').primaryKey(),
-  phone: varchar('phone', { length: 256 }),
+  phone: varchar('phone', { length: 255 }),
   userId: int('user_id').references(() => users.id),
 });
 ```
@@ -33,13 +33,13 @@ And it will generate a migration SQL file
 ```sql copy
 CREATE TABLE `users` (
  `id` int PRIMARY KEY,
- `full_name` varchar(256)
+ `full_name` varchar(255)
 );
 
 
 CREATE TABLE `auth_otp` (
  `id` serial PRIMARY KEY,
- `phone` varchar(256),
+ `phone` varchar(255),
  `user_id` int
 );
 
@@ -48,8 +48,8 @@ ALTER TABLE auth_otp ADD CONSTRAINT auth_otp_user_id_users_id_fk FOREIGN KEY (`u
 CREATE INDEX name_idx ON users (`full_name`);
 ```
 
-We've designed Drizzle ORM to be an opt-in solution at any point of your development flow.  
-You can opt-in to run generated migrations with Drizzle or run it elsewhere wherever its suitable for you  
+We've designed Drizzle ORM to be an opt-in solution at any point of your development flow.
+You can opt-in to run generated migrations with Drizzle or run it elsewhere wherever its suitable for you
 To run them with Drizzle
 ```typescript copy
 import { drizzle } from 'drizzle-orm/mysql2';

--- a/pages/docs/quick-start.mdx
+++ b/pages/docs/quick-start.mdx
@@ -32,7 +32,7 @@ import { pgTable, serial, text, varchar } from "drizzle-orm/pg-core";
 export const users = pgTable('users', {
   id: serial('id').primaryKey(),
   fullName: text('full_name'),
-  phone: varchar('phone', { length: 256 }),
+  phone: varchar('phone', { length: 255 }),
 });
 ```
 

--- a/pages/docs/sql-schema-declaration.mdx
+++ b/pages/docs/sql-schema-declaration.mdx
@@ -2,7 +2,7 @@ import { Tab, Tabs } from 'nextra-theme-docs';
 
 # SQL schema declaration
 
-You declare SQL schema in TypeScript in either one `schema.ts` file 
+You declare SQL schema in TypeScript in either one `schema.ts` file
 or you can group them logically in multiple logically grouped files, whichever you prefer, all the freedom!
 
 ```plaintext
@@ -33,11 +33,11 @@ or you can group them logically in multiple logically grouped files, whichever y
     │  └ 📜 handler.ts
     ├ 📂 get-city
     │  ├ 📜 city.ts
-    │  └ 📜 handler.ts    
+    │  └ 📜 handler.ts
     ├  ...
 ```
 
-You can declare tables, indexes and constraints, foreign keys and enums.  
+You can declare tables, indexes and constraints, foreign keys and enums.
 Please pay attention to `export` keyword, they are mandatory if you'll be using [drizzle-kit SQL migrations generator](#migrations)
 <Tabs items={['PostgreSQL', 'MySQL', 'SQLite']}>
   <Tab>
@@ -49,7 +49,7 @@ Please pay attention to `export` keyword, they are mandatory if you'll be using 
 
   export const countries = pgTable('countries', {
     id: serial('id').primaryKey(),
-    name: varchar('name', { length: 256 }),
+    name: varchar('name', { length: 255 }),
   }, (countries) => {
     return {
       nameIndex: uniqueIndex('name_idx').on(countries.name),
@@ -58,7 +58,7 @@ Please pay attention to `export` keyword, they are mandatory if you'll be using 
 
   export const cities = pgTable('cities', {
     id: serial('id').primaryKey(),
-    name: varchar('name', { length: 256 }),
+    name: varchar('name', { length: 255 }),
     countryId: integer('country_id').references(() => countries.id),
     popularity: popularityEnum('popularity'),
   });
@@ -73,7 +73,7 @@ Please pay attention to `export` keyword, they are mandatory if you'll be using 
   const users = pgTable('users', {
     id: serial('id').primaryKey(),
     fullName: text('full_name'),
-    phone: varchar('phone', { length: 256 }),
+    phone: varchar('phone', { length: 255 }),
   });
 
   export type User = InferModel<typeof users>; // return type when queried
@@ -96,20 +96,20 @@ Please pay attention to `export` keyword, they are mandatory if you'll be using 
   // declaring enum in database
   export const countries = mysqlTable('countries', {
     id: serial('id').primaryKey(),
-    name: varchar('name', { length: 256 }),
+    name: varchar('name', { length: 255 }),
   }, (countries) => ({
     nameIndex: uniqueIndex('name_idx').on(countries.name),
   }));
 
   export const cities = mysqlTable('cities', {
     id: serial('id').primaryKey(),
-    name: varchar('name', { length: 256 }),
+    name: varchar('name', { length: 255 }),
     countryId: int('country_id').references(() => countries.id),
     popularity: mysqlEnum('popularity', ['unknown', 'known', 'popular']),
   });
   ```
 
-  Database and table explicit entity types:  
+  Database and table explicit entity types:
   ```typescript copy
   import { MySqlDatabase, MySqlRawQueryResult, mysqlTable, serial, text, varchar } from 'drizzle-orm/mysql-core';
   import { InferModel } from 'drizzle-orm';
@@ -119,7 +119,7 @@ Please pay attention to `export` keyword, they are mandatory if you'll be using 
   const users = mysqlTable('users', {
     id: serial('id').primaryKey(),
     fullName: text('full_name'),
-    phone: varchar('phone', { length: 256 }),
+    phone: varchar('phone', { length: 255 }),
   });
 
   export type User = InferModel<typeof users>; // return type when queried
@@ -128,7 +128,7 @@ Please pay attention to `export` keyword, they are mandatory if you'll be using 
 
   // init mysql2 Pool or Client
   const poolConnection = mysql.createPool({
-      host:'localhost', 
+      host:'localhost',
       user: 'root',
       database: 'test'
   });


### PR DESCRIPTION
Fixed spelling errors in the documentation related to declaration of multiple fields. The problem occurred when the length of the varchar data type exceeded the maximum limit of 255 characters.