### PR TITLE
Code example typo fix in mysql connection page

### DIFF
--- a/pages/docs/installation-and-db-connection/mysql/mysql2.mdx
+++ b/pages/docs/installation-and-db-connection/mysql/mysql2.mdx
@@ -60,7 +60,7 @@ For querying purposes feel free to use either `client` or `pool` based on your b
     ...
   });
 
-  const db = drizzle(connection);
+  const db = drizzle(poolConnection);
   ```
   </Tab>
 </Tabs>


### PR DESCRIPTION
Found a code example typo in ```mysql``` connection doc page

(```connection``` changed to ```poolConnection```)

![242502016-5c0ddcf8-d156-4560-8af0-c385b1c1dfb8](https://github.com/drizzle-team/drizzle-orm-docs/assets/76561420/4d184814-6214-43de-9adf-2c13ea3e1857)
