### PR TITLE
Update callout link for `drizzle-kid drops` to correct URL

### DIFF
--- a/pages/kit-docs/conf.mdx
+++ b/pages/kit-docs/conf.mdx
@@ -138,7 +138,7 @@ and have different migration folders for them.
   
 Migration folder contains `.sql` migration files and `_meta` folder which is used by `drizzle-kit`
 <Callout type="warning" emoji="⚠️">
-	Don't delete any files manually, please refer to [`drizzle-kit drop`](./commands/drop) command
+	Don't delete any files manually, please refer to [`drizzle-kit drop`](./commands#drop-migration) command
 </Callout>
 
 <Section>


### PR DESCRIPTION
On the [drizzle-kit config docs](https://orm.drizzle.team/kit-docs/conf#migrations-folder) the callout:
```
Don't delete any files manually, please refer to drizzle-kit drop command
```
links to a deprecated page `/commands/drop`. 

Updated link to point to [/commands#drop-migration](https://orm.drizzle.team/kit-docs/commands#drop-migration) instead.