### PR TITLE
docs: remove extra parameter destructuring in one-to-one usersRelations example

### DIFF
--- a/pages/docs/rqb.mdx
+++ b/pages/docs/rqb.mdx
@@ -91,7 +91,7 @@ export const users = pgTable('users', {
 	invitedBy: integer('invited_by'),
 });
 
-export const usersRelations = relations(users, ({ one, many }) => ({
+export const usersRelations = relations(users, ({ one }) => ({
 	invitee: one(users, {
 		fields: [users.invitedBy],
 		references: [users.id],


### PR DESCRIPTION
Found the `many` parameter is not actually used in the example.