### PR TITLE
typo : fix typo on  conf.mdx

### DIFF
--- a/pages/kit-docs/conf.mdx
+++ b/pages/kit-docs/conf.mdx
@@ -114,7 +114,7 @@ export default {
  │ ├ 📂 schema
  │ │ ├ 📜 user.ts 
  │ │ ├ 📜 post.ts 
- │ │ └ 📜 commnet.ts 
+ │ │ └ 📜 comment.ts 
  │ └ 📜 index.ts
  ├ 📜 drizzle.config.ts
  └ 📜 package.json
@@ -149,7 +149,7 @@ Migration folder contains `.sql` migration files and `_meta` folder which is use
  │ ├ 📂 _meta
  │ ├ 📜 user.ts 
  │ ├ 📜 post.ts 
- │ └ 📜 commnet.ts 
+ │ └ 📜 comment.ts 
  ├ 📂 src
  ├ 📜 drizzle.config.ts
  └ 📜 package.json


### PR DESCRIPTION
Typo error in Drizzle Kit Configuration doc