### PR TITLE
Fix typo in meta description

### DIFF
--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -23,7 +23,7 @@ const config: DocsThemeConfig = {
     }
     return {
       titleTemplate: 'DrizzleORM - next gen TypeScript ORM',
-      description: 'Drizzle ORM is a lightweigh and performant TypeScript ORM with developer experience in mind',
+      description: 'Drizzle ORM is a lightweight and performant TypeScript ORM with developer experience in mind',
     };
   },
   logo: (


### PR DESCRIPTION
Fixes the homepage embed typo
<img width="527" alt="screenshot of https://orm.drizzle.team/ embed in Discord showing typo" src="https://github.com/drizzle-team/drizzle-orm-docs/assets/71605633/a6813fea-0b07-47b4-9a47-61353e796504">

Please take your time to thoroughly review this 1 character addition
