### PR TITLE
fix: SQL-schema-declaration-type-error

### DIFF
--- a/pages/docs/sql-schema-declaration.mdx
+++ b/pages/docs/sql-schema-declaration.mdx
@@ -84,7 +84,7 @@ Please pay attention to `export` keyword, they are mandatory if you'll be using 
 
   const result: User[] = await db.select().from(users);
 
-  export async function insertUser(user: NewUser): Promise<User> {
+  export async function insertUser(user: NewUser): Promise<User[]> {
     return db.insert(users).values(user).returning();
   }
   ```


### PR DESCRIPTION
getting error from the return type in schema declaration example, which should be array of users

![image](https://github.com/drizzle-team/drizzle-orm-docs/assets/6829451/1fef76ce-5120-4394-9fc3-57522a80105f)
