### PR TITLE
Add information about defaultNow() not working for PlanetScale

### DIFF
--- a/pages/docs/column-types/mysql.mdx
+++ b/pages/docs/column-types/mysql.mdx
@@ -483,6 +483,8 @@ CREATE TABLE `table` (
 </Section>
 
 <Section>
+If you are using PlanetScale `defaultNow()` will not work. A PlanetScale alternative `defaultCurrentTimestamp()` will be released in the future. In the meantime use `default(sql'CURRENT_TIMESTAMP')`
+<br />
 ```typescript
 import { timestamp, mysqlTable } from "drizzle-orm/mysql-core";
 


### PR DESCRIPTION
Add information that defaultNow() does not work for PlanetScale, that an alternative is in the works and what to use in the meantime.

Link to discord thread - https://discord.com/channels/1043890932593987624/1102406885644189797/1103909888377233538
