### PR TITLE
fix(sqlite): update InferModel import location for SQLite example

### DIFF
--- a/pages/docs/sql-schema-declaration.mdx
+++ b/pages/docs/sql-schema-declaration.mdx
@@ -164,7 +164,8 @@ Please pay attention to `export` keyword, they are mandatory if you'll be using 
   Database and table explicit entity types
 
   ```typescript copy
-  import { InferModel, text, integer, sqliteTable } from 'drizzle-orm/sqlite-core';
+  import type { InferModel } from 'drizzle-orm';
+  import { text, integer, sqliteTable } from 'drizzle-orm/sqlite-core';
 
   const users = sqliteTable('users', {
     id: integer('id').primaryKey(),


### PR DESCRIPTION
Fixed a small error in the docs, the `InferModel` should be imported from `'drizzle-orm'`, not `'drizzle-orm/sqlite-core'`. Thanks for the awesome work on this project! :smile:  I've been enjoying working with it a lot on a side project of mine lately.