### PR TITLE
Docs: Fixed typo in Relational queries page.

### DIFF
--- a/pages/docs/rqb.mdx
+++ b/pages/docs/rqb.mdx
@@ -111,7 +111,7 @@ export const users = pgTable('users', {
 
 export const usersRelations = relations(users, ({ one }) => ({
 	profileInfo: one(profileInfo, {
-		fields: [user.id],
+		fields: [users.id],
 		references: [profileInfo.userId],
 	}),
 }));


### PR DESCRIPTION
Fixed typo where the "users" table was referenced as "user". This change resolves #52.