### PR TITLE
Enable "Copy" button for Quickstart Schema File

### DIFF
--- a/pages/docs/quick-start.mdx
+++ b/pages/docs/quick-start.mdx
@@ -26,7 +26,7 @@ For the quick start example we're going to use PostgresJS driver
 </Tabs>
 
 #### Declare your first schema file
-```typescript filename="schema.ts"
+```typescript copy filename="schema.ts"
 import { pgTable, serial, text, varchar } from "drizzle-orm/pg-core";
 
 export const users = pgTable('users', {


### PR DESCRIPTION
This PR introduces an enhancement by enabling the "Copy" button functionality for the Quickstart Database Schema. This feature aims to expedite the setup process for users.

**before:**
![image](https://github.com/drizzle-team/drizzle-orm-docs/assets/54599584/9298b0cf-dd10-46e4-b126-cca6a2ff77f9)

**after:**
![image](https://github.com/drizzle-team/drizzle-orm-docs/assets/54599584/abbc1a6a-cf4b-4f9e-b335-384cdc96e284)
