### PR TITLE
Improve supported databases UI (implement IsSupportedChip, IsSupportedChipGroup components

### DIFF
--- a/components/Icons/Icons.tsx
+++ b/components/Icons/Icons.tsx
@@ -1,5 +1,19 @@
 import React from 'react';
 
+export const CheckIcon = () => (
+  // Mini (20px) 'check' icon from: https://heroicons.com/
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" width="20" height="20">
+    <path fillRule="evenodd" d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z" clipRule="evenodd" />
+  </svg>
+);
+
+export const XIcon = () => (
+  // Mini (20px) 'x-mark' icon from: https://heroicons.com/
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" width="20" height="20">
+    <path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z" />
+  </svg>
+);
+
 export const CloudRainActiveIcon = () => (
   <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
     <rect width="24" height="24" rx="6" fill="#008AE6" fillOpacity="0.2" />

--- a/components/IsSupportedChip/IsSupportedChip.module.css
+++ b/components/IsSupportedChip/IsSupportedChip.module.css
@@ -1,0 +1,63 @@
+.is-supported-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 1px 6px;
+  border-radius: 5px;
+  flex-shrink: 0;
+  background: #292829;
+  border: 1px solid #3F3D3F;
+}
+
+.is-supported-yes {
+  /* Uncomment for higher visual hierarchy style */
+  /* border: none;
+  background: #273D2E; */
+  color: #47B66D;
+}
+
+.is-supported-no {
+  /* Uncomment for higher visual hierarchy style */
+  /* border: none;
+  background: #3A2828; */
+  color: #f36464;
+}
+
+.is-supported svg {
+  flex-shrink: 0;
+}
+
+.is-supported-text {
+  font-size: 14px;
+  font-weight: 500;
+  font-family: monospace, 'Menlo';
+  color: #D8DEE6;
+}
+
+.is-supported-chip-group {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  padding-top: 24px;
+}
+
+.is-supported-chip-group-joined {
+  gap: 0px;
+}
+
+.is-supported-chip-group-joined .is-supported-chip {
+  border-radius: 0px;
+  border-left: none;
+  padding-right: 10px;
+}
+
+.is-supported-chip-group-joined .is-supported-chip:first-child {
+  border-left: 1px solid #3F3D3F;
+  border-top-left-radius: 5px;
+  border-bottom-left-radius: 5px;
+}
+
+.is-supported-chip-group-joined .is-supported-chip:last-child {
+  border-top-right-radius: 5px;
+  border-bottom-right-radius: 5px;
+}

--- a/components/IsSupportedChip/IsSupportedChip.tsx
+++ b/components/IsSupportedChip/IsSupportedChip.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import styles from './IsSupportedChip.module.css';
+import { XIcon, CheckIcon } from '../Icons/Icons';
+
+interface Props {
+  isSupported: boolean;
+  text: string;
+}
+
+const IsSupportedChip:React.FC<Props> = ({ isSupported, text }) => (
+  <div className={`${styles['is-supported-chip']} ${isSupported ? styles['is-supported-yes'] : styles['is-supported-no']}`}>
+    {isSupported
+      ? <CheckIcon />
+      : <XIcon />}
+    <div className={styles['is-supported-text']}>{text}</div>
+  </div>
+);
+
+export default IsSupportedChip;

--- a/components/IsSupportedChip/IsSupportedChipGroup.tsx
+++ b/components/IsSupportedChip/IsSupportedChipGroup.tsx
@@ -1,0 +1,19 @@
+import IsSupportedChip from './IsSupportedChip';
+import styles from './IsSupportedChip.module.css';
+
+interface Props {
+  chips: Record<string, boolean>;
+  joined?: boolean;
+}
+
+const IsSupportedChipGroup:React.FC<Props> = ({ chips, joined }) => (
+  <div className={`${styles['is-supported-chip-group']} ${joined ? styles['is-supported-chip-group-joined'] : ''}`}>
+    {
+        Object.entries(chips).map(([text, isSupported]) => (
+          <IsSupportedChip isSupported={isSupported} text={text} />
+        ))
+    }
+  </div>
+);
+
+export default IsSupportedChipGroup;

--- a/pages/docs/crud.mdx
+++ b/pages/docs/crud.mdx
@@ -1,6 +1,7 @@
 import Section from '../../components/Section/Section';
 import { Tab, Tabs } from 'nextra-theme-docs';
 import { Callout } from 'nextra-theme-docs'
+import IsSupportedChipGroup from '../../components/IsSupportedChip/IsSupportedChipGroup';
 
 # Quering with SQL-like syntax [CRUD]
 Drizzle ORM provide you the most SQL-like way to query your relational database.  
@@ -538,7 +539,7 @@ await insertUser(newUser);
 ```
 
 ### Insert returning
-`✓ PostgreSQL` `✓ SQLite` `✕ MySQL`  
+<IsSupportedChipGroup chips={{ 'PostgreSQL': true, 'SQLite': true, 'MySQL': false }} />
 You can insert a row and get it back in PostgreSQL and SQLite
 ```typescript copy
 await db.insert(users).values({ name: "Dan" }).returning();
@@ -594,7 +595,7 @@ await db.update(users)
 ```
 
 ### Update with returning
-`✓ PostgreSQL` `✓ SQLite` `✕ MySQL`  
+<IsSupportedChipGroup chips={{ 'PostgreSQL': true, 'SQLite': true, 'MySQL': false }} />
 You can update a row and get it back in PostgreSQL and SQLite
 ```typescript copy
 const updatedUserId: { updatedId: number }[] = await db.update(users)
@@ -616,7 +617,7 @@ await db.delete(users).where(eq(users.name, 'Dan'));
 ```
 
 ### Delete with return
-`✓ PostgreSQL` `✓ SQLite` `✕ MySQL`  
+<IsSupportedChipGroup chips={{ 'PostgreSQL': true, 'SQLite': true, 'MySQL': false }} />
 You can delete a row and get it back in PostgreSQL and SQLite
 ```typescript copy
 const deletedUser = await db.delete(users)

--- a/pages/docs/operators.mdx
+++ b/pages/docs/operators.mdx
@@ -1,5 +1,6 @@
 import { Tab, Tabs } from 'nextra-theme-docs';
 import Section from '../../components/Section/Section';
+import IsSupportedChipGroup from '../../components/IsSupportedChip/IsSupportedChipGroup';
 
 # Filter and conditional operators
 We natively support all dialect spicific filter and conditional operators  
@@ -9,7 +10,7 @@ import { eq, ne, gt, gte, ... } from "drizzle-orm";
 ```
 
 ### eq
-`✓ PostgreSQL` `✓ MySQL` `✓ SQLite`  
+<IsSupportedChipGroup chips={{ 'PostgreSQL': true, 'MySQL': true, 'SQLite': true }} />
   
 Value equal to `n`
 <Section>
@@ -40,7 +41,7 @@ SELECT * FROM table WHERE table.column1 = table.column2
 
 
 ### ne
-`✓ PostgreSQL` `✓ MySQL` `✓ SQLite`  
+<IsSupportedChipGroup chips={{ 'PostgreSQL': true, 'MySQL': true, 'SQLite': true }} />
   
 Value is not equal to `n`  
 <Section>
@@ -70,7 +71,7 @@ SELECT * FROM table WHERE table.column1 <> table.column2
 
 
 ### gt
-`✓ PostgreSQL` `✓ MySQL` `✓ SQLite`  
+<IsSupportedChipGroup chips={{ 'PostgreSQL': true, 'MySQL': true, 'SQLite': true }} /> 
   
 Value is greater than `n`
 <Section>
@@ -99,7 +100,7 @@ SELECT * FROM table WHERE table.column1 > table.column2
 </Section>
 
 ### gte
-`✓ PostgreSQL` `✓ MySQL` `✓ SQLite`  
+<IsSupportedChipGroup chips={{ 'PostgreSQL': true, 'MySQL': true, 'SQLite': true }} />
   
 Value is greater than or equal to `n`
 <Section>
@@ -128,7 +129,7 @@ SELECT * FROM table WHERE table.column1 >= table.column2
 </Section>
 
 ### lt
-`✓ PostgreSQL` `✓ MySQL` `✓ SQLite`  
+<IsSupportedChipGroup chips={{ 'PostgreSQL': true, 'MySQL': true, 'SQLite': true }} />
   
 Value is less than `n`
 <Section>
@@ -157,7 +158,7 @@ SELECT * FROM table WHERE table.column1 < table.column2
 </Section>
 
 ### lte
-`✓ PostgreSQL` `✓ MySQL` `✓ SQLite`  
+<IsSupportedChipGroup chips={{ 'PostgreSQL': true, 'MySQL': true, 'SQLite': true }} />
   
 Value is less than or equal to `n`.
 
@@ -187,7 +188,7 @@ SELECT * FROM table WHERE table.column1 <= table.column2
 
 
 ### isNull
-`✓ PostgreSQL` `✓ MySQL` `✓ SQLite`  
+<IsSupportedChipGroup chips={{ 'PostgreSQL': true, 'MySQL': true, 'SQLite': true }} />
   
 Value is `null`
 <Section>
@@ -204,7 +205,7 @@ SELECT * FROM table WHERE table.column IS NULL
 
 
 ### isNotNull
-`✓ PostgreSQL` `✓ MySQL` `✓ SQLite`  
+<IsSupportedChipGroup chips={{ 'PostgreSQL': true, 'MySQL': true, 'SQLite': true }} />
   
 Value is not `null`
 <Section>
@@ -220,7 +221,7 @@ SELECT * FROM table WHERE table.column IS NOT NULL
 </Section>
 
 ### inArray
-`✓ PostgreSQL` `✓ MySQL` `✓ SQLite`  
+<IsSupportedChipGroup chips={{ 'PostgreSQL': true, 'MySQL': true, 'SQLite': true }} />
   
 Value is in array of values
 <Section>
@@ -249,7 +250,7 @@ SELECT * FROM table WHERE table.column IN (SELECT table2.column FROM table2)
 </Section>
 
 ### notInArray
-`✓ PostgreSQL` `✓ MySQL` `✓ SQLite`  
+<IsSupportedChipGroup chips={{ 'PostgreSQL': true, 'MySQL': true, 'SQLite': true }} />
   
 Value is not in array of values
 <Section>
@@ -278,7 +279,7 @@ SELECT * FROM table WHERE table.column NOT IN (SELECT table2.column FROM table2)
 </Section>
 
 ### exists
-`✓ PostgreSQL` `✓ MySQL` `✓ SQLite`  
+<IsSupportedChipGroup chips={{ 'PostgreSQL': true, 'MySQL': true, 'SQLite': true }} />
   
 Value exists
 <Section>
@@ -310,7 +311,7 @@ SELECT * FROM table WHERE NOT EXISTS (SELECT * from table2)
 </Section>
 
 ### between
-`✓ PostgreSQL` `✓ MySQL` `✓ SQLite`  
+<IsSupportedChipGroup chips={{ 'PostgreSQL': true, 'MySQL': true, 'SQLite': true }} />
   
 Value is between two values
 <Section>
@@ -326,7 +327,7 @@ SELECT * FROM table WHERE table.column BETWEEN 2 AND 7
 </Section>
 
 ### notBetween
-`✓ PostgreSQL` `✓ MySQL` `✓ SQLite`  
+<IsSupportedChipGroup chips={{ 'PostgreSQL': true, 'MySQL': true, 'SQLite': true }} />
   
 Value is not between two value
 <Section>
@@ -342,7 +343,7 @@ SELECT * FROM table WHERE table.column NOT BETWEEN 2 AND 7
 </Section>
 
 ### like
-`✓ PostgreSQL` `✓ MySQL` `✓ SQLite`  
+<IsSupportedChipGroup chips={{ 'PostgreSQL': true, 'MySQL': true, 'SQLite': true }} />
   
 Value is like other value, case sensitive
 <Section>
@@ -358,7 +359,7 @@ SELECT * FROM table  WHERE table.column LIKE '%llo wor%'
 </Section>
 
 ### ilike
-`✓ PostgreSQL` `✕ MySQL` `✕ SQLite`  
+<IsSupportedChipGroup chips={{ 'PostgreSQL': true, 'MySQL': false, 'SQLite': false }} />
   
 Value is like some other value, case insensitive
 <Section>
@@ -374,7 +375,7 @@ SELECT * FROM table WHERE table.column ILIKE '%llo wor%'
 </Section>
 
 ### notIlike
-`✓ PostgreSQL` `✓ MySQL` `✓ SQLite`  
+<IsSupportedChipGroup chips={{ 'PostgreSQL': true, 'MySQL': true, 'SQLite': true }} />
   
 Value is not like some other value, case insensitive
 <Section>
@@ -390,7 +391,7 @@ SELECT * FROM table WHERE table.column NOT ILIKE '%llo wor%'
 </Section>
 
 ### not
-`✓ PostgreSQL` `✓ MySQL` `✓ SQLite`  
+<IsSupportedChipGroup chips={{ 'PostgreSQL': true, 'MySQL': true, 'SQLite': true }} />
   
 All conditions must return `false`.
 
@@ -407,7 +408,7 @@ SELECT * FROM table WHERE NOT (table.column = 5)
 </Section>
 
 ### and
-`✓ PostgreSQL` `✓ MySQL` `✓ SQLite`  
+<IsSupportedChipGroup chips={{ 'PostgreSQL': true, 'MySQL': true, 'SQLite': true }} />
   
 All conditions must return `true`.
 
@@ -424,7 +425,7 @@ SELECT * FROM table WHERE (table.column > 5 AND table.column < 7)
 </Section>
 
 ### or
-`✓ PostgreSQL` `✓ MySQL` `✓ SQLite`  
+<IsSupportedChipGroup chips={{ 'PostgreSQL': true, 'MySQL': true, 'SQLite': true }} />
   
 One or more conditions must return `true`.
 

--- a/pages/docs/schemas.mdx
+++ b/pages/docs/schemas.mdx
@@ -1,9 +1,10 @@
 import { Tab, Tabs } from "nextra-theme-docs";
 import Section from "../../components/Section/Section";
+import IsSupportedChipGroup from '../../components/IsSupportedChip/IsSupportedChipGroup';
 
 # Table schemas
 
-`✓ PostgreSQL` `✓ MySQL` `✕ SQLite`
+<IsSupportedChipGroup chips={{ 'PostgreSQL': true, 'MySQL': true, 'SQLite': false }} />
 
 Drizzle ORM provides you an API for declaring SQL schemas for PostgreSQL and MySQL dialects  
 If you declare table within a schema - query builder will prepend schema names in queries `select * from "schema"."users"`

--- a/pages/docs/views.mdx
+++ b/pages/docs/views.mdx
@@ -1,7 +1,7 @@
 import { Callout } from 'nextra-theme-docs';
 import { Tab, Tabs } from "nextra-theme-docs";
 import Section from "../../components/Section/Section";
-
+import IsSupportedChipGroup from '../../components/IsSupportedChip/IsSupportedChipGroup';
 
 # Views (WIP)
 <Callout type="warning" emoji="⚠️">
@@ -242,7 +242,8 @@ export const trimmedUser = pgMaterializedView("trimmed_user", {
 ```
 
 ### Materialized views
-`✓ PostgreSQL` `✕ MySQL` `✕ SQLite`  
+<IsSupportedChipGroup chips={{ 'PostgreSQL': true, 'MySQL': false, 'SQLite': false }} />
+
 According to their official docs, PostgreSQL has [`regular`](https://www.postgresql.org/docs/current/sql-createview.html) 
 and [`materialized`](https://www.postgresql.org/docs/current/sql-creatematerializedview.html)  
   


### PR DESCRIPTION
This is an implementation of option 2 from this issue: https://github.com/drizzle-team/drizzle-orm/issues/864

It changes the "database support UI" from this:

![image](https://github.com/drizzle-team/drizzle-orm-docs/assets/25141252/695c2fd2-1b8c-483d-afa3-255efae603f6)

To this:

![image](https://github.com/drizzle-team/drizzle-orm-docs/assets/25141252/c22e7c07-26f8-4527-8f82-e17cd546d80b)

The additional spacing is just a consequence of how the MDX files get rendered with the injected component instead of the previous backticks UI. If necessary, I can try to reverse-engineer the rendering and remove the spacing, but it looks ok in context, IMHO. 

Also, I implemented option 3 as an alternative if you decide to go that route, and commented out the CSS:
```css
.is-supported-yes {
  /* Uncomment for higher visual hierarchy style */
  /* border: none;
  background: #273D2E; */
  color: #47B66D;
}

.is-supported-no {
  /* Uncomment for higher visual hierarchy style */
  /* border: none;
  background: #3A2828; */
  color: #f36464;
}
```
When uncommented, it looks like this:

![image](https://github.com/drizzle-team/drizzle-orm-docs/assets/25141252/854d5702-9902-47c4-9d6f-e84695545fcd)

Finally, I also added an optional `joined` prop on the `IsSupportedChipGroup` component which makes it look like this:
```ts
<IsSupportedChipGroup chips={{ 'PostgreSQL': true, 'SQLite': true, 'MySQL': false }} joined={true} />
```
![image](https://github.com/drizzle-team/drizzle-orm-docs/assets/25141252/3d39abca-6cad-43f0-85b4-c92f371faed6)

By default, I left them all un-joined, but let me know if you prefer this!