### PR TITLE
code sample param name correction: `db` -> `database`

### DIFF
--- a/pages/kit-docs/commands.mdx
+++ b/pages/kit-docs/commands.mdx
@@ -118,7 +118,7 @@ export default {
     password: "password",
     host: "127.0.0.1",
     port: 5432,
-    db: "db",
+    database: "db",
   }
 } satisfies Config;
 ```


### PR DESCRIPTION
Seen in Sample 2 on https://orm.drizzle.team/kit-docs/commands#introspect--pull