### PR TITLE
Fixed broken link to migrations page in sql-schema-declaration.mdx

### DIFF
--- a/pages/docs/sql-schema-declaration.mdx
+++ b/pages/docs/sql-schema-declaration.mdx
@@ -38,7 +38,7 @@ or you can group them logically in multiple logically grouped files, whichever y
 ```
 
 You can declare tables, indexes and constraints, foreign keys and enums.  
-Please pay attention to `export` keyword, they are mandatory if you'll be using [drizzle-kit SQL migrations generator](#migrations)
+Please pay attention to `export` keyword, they are mandatory if you'll be using [drizzle-kit SQL migrations generator](./migrations)
 <Tabs items={['PostgreSQL', 'MySQL', 'SQLite']}>
   <Tab>
   ```typescript copy


### PR DESCRIPTION
Replaced a named anchor with a proper link