### PR TITLE
docs: fix many to many example

### DIFF
--- a/pages/docs/rqb.mdx
+++ b/pages/docs/rqb.mdx
@@ -734,7 +734,7 @@ const res = await db.query.users.findMany({
 	},
 	with: {
 		usersToGroups: {
-			columns: {
+			with: {
 				group: true,
 			},
 		},


### PR DESCRIPTION
I tried to run the example locally but there is an issue with a query, take a look at screenshots to get it:
currently in the docs:
![image](https://github.com/drizzle-team/drizzle-orm-docs/assets/11430775/89d445cb-f22d-45df-b723-7ed5c659ed99)

with the fix:
![image](https://github.com/drizzle-team/drizzle-orm-docs/assets/11430775/0e3c72e9-f0ef-4a27-a648-a13f9ca25a2a)
