### PR TITLE
Remove duplicate code in relations comparison

### DIFF
--- a/pages/docs/rqb.mdx
+++ b/pages/docs/rqb.mdx
@@ -272,7 +272,7 @@ You can define `relations` without using foreign keys (and vice versa), which al
 The following two examples will work exactly the same in terms of querying the data using Drizzle relational queries.
 <CodeTabs items={["schema1.ts", "schema2.ts"]}>
 <CodeTab>
-```ts {15}
+```ts {6-11}
 export const users = pgTable('users', {
 	id: serial('id').primaryKey(),
 	name: text('name'),
@@ -293,7 +293,7 @@ export const profileInfo = pgTable('profile_info', {
 ```
 </CodeTab>
 <CodeTab>
-```ts {15}
+```ts {8}
 export const users = pgTable('users', {
 	id: serial('id').primaryKey(),
 	name: text('name'),

--- a/pages/docs/rqb.mdx
+++ b/pages/docs/rqb.mdx
@@ -299,13 +299,6 @@ export const users = pgTable('users', {
 	name: text('name'),
 });
 
-export const usersRelations = relations(users, ({ one, many }) => ({
-	profileInfo: one(users, {
-		fields: [profileInfo.userId],
-		references: [users.id],
-	}),
-}));
-
 export const profileInfo = pgTable('profile_info', {
 	id: serial('id').primaryKey(),
 	userId: integer("user_id").references(() => users.id),


### PR DESCRIPTION
The purpose of the examples below are to show

> The following two examples will work exactly the same in terms of querying the data using Drizzle relational queries.

The comparison is more clear when the relation is compared to the foreign key reference, without the explicit relation in both examples.

## Before

![image](https://github.com/drizzle-team/drizzle-orm-docs/assets/71605633/85ab363c-e7e2-473c-a896-70d3902797ab)

## After

![image](https://github.com/drizzle-team/drizzle-orm-docs/assets/71605633/ff937701-1daf-421b-93be-dd12a0a1a2bf)
