### PR TITLE
docs: add comment for sqlite url config

### DIFF
--- a/pages/kit-docs/config-reference.mdx
+++ b/pages/kit-docs/config-reference.mdx
@@ -176,7 +176,7 @@ export default {
 ```ts
 export default {
   dbCredentials: {
-    url: '',
+    url: '', // 👈 this could also be a path to the local sqlite file
   }
 } satisfies Config;
 ```


### PR DESCRIPTION
As I was trying to make studio work for my local setup, I blindly followed the instructions and just added `url: ""` to the config. 
Then, obviously, I ran into some errors.

I then googled and ran into the following article and saw the `url` could also be used as "path for the local file".

In hindsight it's obvious, while trying to make it work, it wasn't
So I thought to add this to save the time for others