### PR TITLE
fix typo in configuration reference page

### DIFF
--- a/pages/kit-docs/config-reference.mdx
+++ b/pages/kit-docs/config-reference.mdx
@@ -310,7 +310,7 @@ This section is a reference to `introspect` object inside `drizzle.config.*` fil
 - **Commands**: 
 
 This command is responsible for a strategy for choosing column, table, constraint JS key names while introspecting 
-your databse
+your database
 
 **Usage**
 ```ts

--- a/pages/kit-docs/config-reference.mdx
+++ b/pages/kit-docs/config-reference.mdx
@@ -305,7 +305,7 @@ This section is a reference to `introspect` object inside `drizzle.config.*` fil
 
 #### casing
 
-- **Type**: `'peserve' | 'camel'`
+- **Type**: `'preserve' | 'camel'`
 - **Default**: `camel`
 - **Commands**: 
 


### PR DESCRIPTION
Fix small typo in configuration reference page of Drizzle kit, "casing" section