### PR TITLE
use ES6 notation for dotenv import

### DIFF
--- a/pages/drizzle-studio/overview.mdx
+++ b/pages/drizzle-studio/overview.mdx
@@ -58,8 +58,7 @@ export const users = pgTable('users', {
 Check out extended config file [docs](/kit-docs/conf)
 ```typescript copy filename="drizzle.config.ts"
 import type { Config } from "drizzle-kit";
-import * as dotenv from "dotenv";
-dotenv.config();
+import "dotenv/config";
  
 export default {
   schema: "./schema/*",

--- a/pages/kit-docs/conf.mdx
+++ b/pages/kit-docs/conf.mdx
@@ -188,8 +188,7 @@ We mirror connection params of database drivers
 <Tab>
 ```ts {6}
 import type { Config } from "drizzle-kit";
-import * as dotenv from "dotenv";
-dotenv.config();
+import "dotenv/config";
 
 export default {
   schema: "./src/schema/*",
@@ -208,8 +207,7 @@ When using the PlanetScale driver, your connection string must end with `?ssl={"
 <Tab>
 ```ts {6-10}
 import type { Config } from "drizzle-kit";
-import * as dotenv from "dotenv";
-dotenv.config();
+import "dotenv/config";
 
 export default {
   schema: "./src/schema/*",
@@ -246,8 +244,7 @@ const users = pgTable('users', {
 ```
 ```ts {7}
 import type { Config } from "drizzle-kit";
-import * as dotenv from "dotenv";
-dotenv.config();
+import "dotenv/config";
 
 export default {
   schema: "./src/schema/*",


### PR DESCRIPTION
i think we can use this syntax
```diff
-import * as dotenv from "dotenv";
-dotenv.config();
+import "dotenv/config";
```

[dotenv docs](https://www.npmjs.com/package/dotenv#how-do-i-use-dotenv-with-import)

-----
<a href="https://stackblitz.com/~/github/cirolosapio/drizzle-orm-docs/tree/master"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz Codeflow" align="left" width="103" height="20"></a> _Submitted with [StackBlitz Codeflow](https://stackblitz.com/~/github/cirolosapio/drizzle-orm-docs/tree/master)._