### PR TITLE
fix: postgres uuid declaration

### DIFF
--- a/pages/docs/column-types/pg.mdx
+++ b/pages/docs/column-types/pg.mdx
@@ -629,7 +629,7 @@ const table = pgTable('table', {
 	integer1: integer('integer1').default(42),
 	integer2: integer('integer2').default(sql`'42'::integer`),
 	uuid1: uuid('uuid1').defaultRandom(),
-	uuid2: uuid('uuid2').default(sql`get_random_uuid()`),
+	uuid2: uuid('uuid2').default(sql`gen_random_uuid()`),
 });
 ```
 

--- a/pages/docs/indexes-constraints.mdx
+++ b/pages/docs/indexes-constraints.mdx
@@ -31,7 +31,7 @@ a string constant, a blob constant, a signed-number, or any constant expression 
       integer1: integer('integer1').default(42),
       integer2: integer('integer2').default(sql`'42'::integer`),
       uuid1: uuid('uuid1').defaultRandom(),
-      uuid2: uuid('uuid2').default(sql`get_random_uuid()`),
+      uuid2: uuid('uuid2').default(sql`gen_random_uuid()`),
     });
     ```
 


### PR DESCRIPTION
On PostgreSQL examples a `get_random_uuid()` is used, this function does not exists and should be changed to `gen_random_uuid()`