### PR TITLE
Cloudflare Workers + Supabase: Replace Pool with Client

### DIFF
--- a/pages/docs/quick-postgresql/node-postgres.mdx
+++ b/pages/docs/quick-postgresql/node-postgres.mdx
@@ -83,3 +83,29 @@ const db = drizzle(pool);
 ```
 </Tab>
 </Tabs>
+
+### Usage with Cloudflare Workers
+
+Now that Cloudflare Workers supports TCP connections, [you can use](https://developers.cloudflare.com/workers/databases/connect-to-postgres/) `node-postgres` to connect to connection poolers, e.g. pgBouncer.
+
+```typescript copy filename="worker.ts"
+import { Client } from "pg";
+import { drizzle } from "drizzle-orm/node-postgres";
+ 
+export default {
+  async fetch(
+    request: Request,
+    env: Env,
+    ctx: ExecutionContext
+  ): Promise<Response> {
+    const client = new Client({ connectionString: env.DATABASE_URL });
+    await client.connect();
+    const db = drizzle(client);
+    const result = await db.select().from(...);
+
+    // Clean up the client, ensuring we don't kill the worker before that is completed.
+    ctx.waitUntil(client.end());
+    return new Response(now);
+  }
+}
+```

--- a/pages/docs/quick-postgresql/supabase.mdx
+++ b/pages/docs/quick-postgresql/supabase.mdx
@@ -67,24 +67,3 @@ const allUsers = await db.select().from(users);
 </Steps>
 
 Connect to your database using the Connection Pooler for serverless environments, and the Direct Connection for long-running servers.
-
-### Usage with Cloudflare Workers
-
-Now that Cloudflare Workers supports TCP connections, you can use [`node-postgres`](./node-postgres) to connect to Supabase's connection pooler.
-
-```typescript copy filename="worker.ts"
-import { Client } from "pg";
-import { drizzle } from "drizzle-orm/node-postgres";
- 
-export default {
-  async fetch(req, env, ctx) {
-    // make sure to use pooling coonection string (i.e. on port 6543)
-    const client = new Client({ connectionString: env.DATABASE_URL });
-    await client.connect();
-    const db = drizzle(client);
-    const result = await db.select().from(...);
-    ctx.waitUntil(client.end());
-    return new Response(now);
-  }
-}
-```

--- a/pages/docs/quick-postgresql/supabase.mdx
+++ b/pages/docs/quick-postgresql/supabase.mdx
@@ -73,15 +73,17 @@ Connect to your database using the Connection Pooler for serverless environments
 Now that Cloudflare Workers supports TCP connections, you can use [`node-postgres`](./node-postgres) to connect to Supabase's connection pooler.
 
 ```typescript copy filename="worker.ts"
-import { Pool } from "pg";
+import { Client } from "pg";
 import { drizzle } from "drizzle-orm/node-postgres";
  
 export default {
   async fetch(req, env, ctx) {
-    const pool = new Pool({ connectionString: env.DATABASE_URL });
-    const db = drizzle(pool)
+    // make sure to use pooling coonection string (i.e. on port 6543)
+    const client = new Client({ connectionString: env.DATABASE_URL });
+    await client.connect();
+    const db = drizzle(client);
     const result = await db.select().from(...);
-    ctx.waitUntil(pool.end());
+    ctx.waitUntil(client.end());
     return new Response(now);
   }
 }


### PR DESCRIPTION
Current docs recommend using `pg`s `Pool` when working with Cloudflare Workers. Yet Workers are supposed to delegate pooling to tools like PgBouncer instead of handling it themselves.

The [official Postgres docs from Cloudflare](https://developers.cloudflare.com/workers/databases/connect-to-postgres/) recommend using `Client` as well.

This PR replaces `Pool` with `Client` in the Workers section of Supabase docs.