### PR TITLE
tiny typo in Drizzle Studio 

### DIFF
--- a/pages/kit-docs/commands.mdx
+++ b/pages/kit-docs/commands.mdx
@@ -302,7 +302,7 @@ $ drizzle-kit check:pg --out=drizzle
 ```
 
 ## Drizzle Studio [NEW]
-`drizzle-kit studio` lets you launce [Drizzle Studio](/drizzle-studio/overview) database browser locally from you config file.  
+`drizzle-kit studio` lets you launch [Drizzle Studio](/drizzle-studio/overview) database browser locally from you config file.  
 
 | param     | required | description              |
 | :-------- | :------- | :----------------------- |


### PR DESCRIPTION
Launch is spelled incorrectly on https://orm.drizzle.team/kit-docs/commands#drizzle-studio-new
<img width="774" alt="Screenshot 2023-09-12 at 11 24 58 PM" src="https://github.com/drizzle-team/drizzle-orm-docs/assets/45720605/98d3d736-9cf9-4402-b263-1620c5b95bc7">
