### PR TITLE
Fix Typo in Documentation Overview (PostrgeSQL => PostgreSQL)

### DIFF
--- a/pages/docs/overview.mdx
+++ b/pages/docs/overview.mdx
@@ -111,7 +111,7 @@ We've spent a lot of time to make sure you have best in class SQL dialects suppo
 so you can have Postgres or MySQL or other dialect-specific stuff support.  
   
 Drizzle is operating natively through industry standard database drivers.  
-We support all major [PostrgeSQL](/docs/quick-postgresql), 
+We support all major [PostgreSQL](/docs/quick-postgresql), 
 [MySQL](/docs/quick-mysql) or [SQLite](/docs/quick-sqlite) drivers out there 
 and we're adding new ones [really fast](https://twitter.com/DrizzleORM/status/1653082492742647811?s=20).  
 
@@ -126,4 +126,4 @@ in both DX and performance and we're always there to help!
 Don't hesitate to reach us out - we'll gladly assist you in your Drizzle journey!  
 We have an outstanding [Discord community](https://driz.li/discord) and welcome to our [Twitter](https://twitter.com/drizzleorm)  
   
-Now go build something awesome with Drizzle and your [PostrgeSQL](/docs/quick-postgresql), [MySQL](/docs/quick-mysql) or [SQLite](/docs/quick-sqlite)!
+Now go build something awesome with Drizzle and your [PostgreSQL](/docs/quick-postgresql), [MySQL](/docs/quick-mysql) or [SQLite](/docs/quick-sqlite)!


### PR DESCRIPTION
Corrects a minor typo in the documentation overview, changing "PostrgeSQL" to "PostgreSQL" Reviewed the codebase to ensure the change is consistent with the other spellings of PostgreSQL.

### Before Changes
<img width="857" alt="image" src="https://github.com/drizzle-team/drizzle-orm-docs/assets/26678464/f1ce10e9-787a-423d-9f94-2984db70ce02">

### After Changes
<img width="869" alt="image" src="https://github.com/drizzle-team/drizzle-orm-docs/assets/26678464/fac4f969-c221-4b65-b392-60c47b14074d">
