### PR TITLE
fix: typo in fulltext search example

### DIFF
--- a/pages/docs/sql.mdx
+++ b/pages/docs/sql.mdx
@@ -438,7 +438,7 @@ const searchParam = "Ale"
 
 await db.select()
         .from(usersTable)
-        .where(sql`to_tsvector('simple', ${usersTable.name}) @@ to_tsquery('simple', '${searchParam}')`)
+        .where(sql`to_tsvector('simple', ${usersTable.name}) @@ to_tsquery('simple', ${searchParam})`)
 ```
 ```sql
 select * from "users" where to_tsvector('simple', "users"."name") @@ to_tsquery('simple', '$1'); --> [ "Ale" ]


### PR DESCRIPTION
The current example for fulltext search leads to an error that is tracked in this issue.
https://github.com/drizzle-team/drizzle-orm/issues/1140

This change should remediate that.