### PR TITLE
fix: %s in descriptions

### DIFF
--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -16,14 +16,8 @@ const config: DocsThemeConfig = {
   },
   useNextSeoProps() {
     const { asPath } = useRouter();
-    if (asPath !== '/') {
-      return {
-        titleTemplate: '%s - DrizzleORM',
-        description: 'Drizzle ORM | %s',
-      };
-    }
     return {
-      titleTemplate: 'DrizzleORM - next gen TypeScript ORM',
+      titleTemplate: asPath === '/' ? 'DrizzleORM - next gen TypeScript ORM' : '%s - DrizzleORM',
       description: 'Drizzle ORM is a lightweight and performant TypeScript ORM with developer experience in mind',
     };
   },


### PR DESCRIPTION
### Before:
![image](https://github.com/drizzle-team/drizzle-orm-docs/assets/35634442/64690c73-8201-4758-8f80-506a72cd2164)
```html
<meta name="description" content="Drizzle ORM | %s">
```
### After:
![image](https://github.com/drizzle-team/drizzle-orm-docs/assets/35634442/0ab89dc9-8e87-4e9b-a573-8266889c38ab)
```html
<meta name="description" content="Drizzle ORM is a lightweight and performant TypeScript ORM with developer experience in mind">
```
