### PR TITLE
Remove deprecated and removed wrangler flags from D1 docs

### DIFF
--- a/pages/docs/quick-sqlite/d1.mdx
+++ b/pages/docs/quick-sqlite/d1.mdx
@@ -26,8 +26,8 @@ database_id = "YOUR DB ID"
 
 To init local database and run server locally
 ```bash
-wrangler d1 execute <DATABASE_NAME> --local --file=./drizzle/0000_short_lockheed.sql
-wrangler dev --local --persist
+wrangler d1 execute <DATABASE_NAME> --file=./drizzle/0000_short_lockheed.sql
+wrangler dev
 ```
 
 Install Drizzle ORM

--- a/pages/docs/quick-sqlite/d1.mdx
+++ b/pages/docs/quick-sqlite/d1.mdx
@@ -26,10 +26,8 @@ database_id = "YOUR DB ID"
 
 To init local database and run server locally
 ```bash
-# remember to add the --local and --persist flags if you are using wrangler below version 3.0.0
-
 wrangler d1 execute <DATABASE_NAME> --local --file=./drizzle/0000_short_lockheed.sql
-wrangler dev
+wrangler dev # on wrangler versions below 3.0.0, add the --local and --persist flags
 ```
 
 Install Drizzle ORM

--- a/pages/docs/quick-sqlite/d1.mdx
+++ b/pages/docs/quick-sqlite/d1.mdx
@@ -26,6 +26,8 @@ database_id = "YOUR DB ID"
 
 To init local database and run server locally
 ```bash
+# remember to add the --local and --persist flags if you are using wrangler below version 3.0.0
+
 wrangler d1 execute <DATABASE_NAME> --file=./drizzle/0000_short_lockheed.sql
 wrangler dev
 ```

--- a/pages/docs/quick-sqlite/d1.mdx
+++ b/pages/docs/quick-sqlite/d1.mdx
@@ -28,7 +28,7 @@ To init local database and run server locally
 ```bash
 # remember to add the --local and --persist flags if you are using wrangler below version 3.0.0
 
-wrangler d1 execute <DATABASE_NAME> --file=./drizzle/0000_short_lockheed.sql
+wrangler d1 execute <DATABASE_NAME> --local --file=./drizzle/0000_short_lockheed.sql
 wrangler dev
 ```
 


### PR DESCRIPTION
Since [wrangler 3.0](https://github.com/cloudflare/workers-sdk/releases/tag/wrangler%403.0.0), the `wrangler dev` `--local` flag was **deprecated**, and running locally became the default behavior. The `--persist` flag was **removed**, and persisting data from D1 also became the default behavior.

This pull request removes mentions to those flags from commands, and adds a reminder for users of older versions, since this was a fairly recent change.