### PR TITLE
fix overflow link issue on icons

### DIFF
--- a/components/pages/LandingPage/LandingComponents/Supporting/SupportingElement/SupportingElement.module.css
+++ b/components/pages/LandingPage/LandingComponents/Supporting/SupportingElement/SupportingElement.module.css
@@ -28,6 +28,7 @@ html[class~=dark] .item {
   height: 54px;
   justify-content: center;
   text-align: center;
+  overflow: hidden;
 }
 
 .icon img {


### PR DESCRIPTION
Hi - I noticed on the home page the https://driz.li/xataio link is overlapping the turso and other svgs and creating an effect where they all link to xataio.

Looks like the issue is the height of the svg is 1200px, I set overflow: hidden to fix this.

![image](https://github.com/drizzle-team/drizzle-orm-docs/assets/62911962/473be76e-ff43-46f3-b237-79f4c73d0e3b)
