### PR TITLE
Update migration export docs

### DIFF
--- a/pages/docs/migrations.mdx
+++ b/pages/docs/migrations.mdx
@@ -27,6 +27,17 @@ export const authOtps = mysqlTable('auth_otp', {
 });
 ```
 
+Ensure all schemas and tables are exported, otherwise the SQL migrations for non-exported schemas and tables will not be generated.
+```typescript copy filename="./src/schema.ts"
+import { pgSchema } from "drizzle-orm/pg-core";
+
+// Will not generate SQL migration
+const financeSchema = pgSchema('finance_schema');
+
+// Will correctly generate SQL migration
+export const userSchema = pgSchema('user_schema')
+```
+
 Run CLI migration command:
 ```bash
 $ pnpm drizzle-kit generate:mysql --schema=./src/schema.ts


### PR DESCRIPTION
Add additional description to the documentation, explaining that all tables and schemas must be exported in order for drizzle-kit to correctly generate SQL migrations.

It's an easy gotcha and I thought worth adding to the docs.

![drizzle-docs-update](https://github.com/drizzle-team/drizzle-orm-docs/assets/53119097/98ec5dcb-a65e-46ae-84f0-8ebcb830a12e)
