### PR TITLE
Disable prepare for supabase connection pooling

### DIFF
--- a/pages/docs/quick-postgresql/supabase.mdx
+++ b/pages/docs/quick-postgresql/supabase.mdx
@@ -56,7 +56,26 @@ import postgres from 'postgres'
 import { users } from './schema'
 
 const connectionString = process.env.DATABASE_URL
-const client = postgres(connectionString)
+
+const client = postgres(connectionString, { prepare: false })
+const db = drizzle(client);
+
+const allUsers = await db.select().from(users);
+```
+
+### Connection pooling (optional)
+
+If you decide to use connection pooling via Supabase (described [here](https://supabase.com/docs/guides/database/connecting-to-postgres#connection-pooler)), and have "Transaction" pool mode enabled, the ensure to turn of prepare as prepared statements are not supported. 
+
+```typescript copy filename="index.ts"
+import { drizzle } from 'drizzle-orm/postgres-js'
+import postgres from 'postgres'
+import { users } from './schema'
+
+const connectionString = process.env.DATABASE_URL
+
+// Disable prefetch as it is not supported for "Transaction" pool mode 
+const client = postgres(connectionString, { prepare: false })
 const db = drizzle(client);
 
 const allUsers = await db.select().from(users);

--- a/pages/docs/quick-postgresql/supabase.mdx
+++ b/pages/docs/quick-postgresql/supabase.mdx
@@ -57,7 +57,7 @@ import { users } from './schema'
 
 const connectionString = process.env.DATABASE_URL
 
-const client = postgres(connectionString, { prepare: false })
+const client = postgres(connectionString)
 const db = drizzle(client);
 
 const allUsers = await db.select().from(users);


### PR DESCRIPTION
Hi Drizzle team 👋

I recently launched a new venture using Supabase + Drizzle on a Next.js app deployed on Vercel. On launch day my app would keep crashing with the following Postgres error prepared statement "xxx" does not exist, this drove me crazy until I searched Postgres.js and found this issue: https://github.com/porsager/postgres/issues/547

I think we should warn users about this in the docs so they don't go crazy finding a solution. Happy to change any other docs as needed, and if I'm in the wrong here please let me know. Always willing to learn mistakes 😅

requested a similar change to Supabase as well: https://github.com/supabase/supabase/pull/18772