### PR TITLE
Add a description for using SQLite with HTTPproxy.

### DIFF
--- a/pages/docs/quick-sqlite/http-proxy.mdx
+++ b/pages/docs/quick-sqlite/http-proxy.mdx
@@ -4,11 +4,11 @@ import { Tab, Tabs } from 'nextra-theme-docs';
 
 Drizzle ORM also supports simply using asynchronous callback function for executing SQL.
 
-- `sql` is a query string with praceholders.
+- `sql` is a query string with placeholders.
 - `params` is an array of parameters.
 - One of the following values will set for `method` depending on the SQL statement - `run`, `all`, `values` or `get`.
 
-Drizzle always waits for `{rows: string[][]}` or `{rows: string[]}` for the retuen value.
+Drizzle always waits for `{rows: string[][]}` or `{rows: string[]}` for the return value.
 
 - When the `method` is `get`, you should return a value as `{rows: string[]}`.
 - Otherwise, you should return `{rows: string[][]}`.

--- a/pages/docs/quick-sqlite/http-proxy.mdx
+++ b/pages/docs/quick-sqlite/http-proxy.mdx
@@ -2,7 +2,20 @@ import { Tab, Tabs } from 'nextra-theme-docs';
 
 # HTTP proxy
 
+Drizzle ORM also supports simply using asynchronous callback function for executing SQL.
+
+- `sql` is a query string with praceholders.
+- `params` is an array of parameters.
+- One of the following values will set for `method` depending on the SQL statement - `run`, `all`, `values` or `get`.
+
+Drizzle always waits for `{rows: string[][]}` or `{rows: string[]}` for the retuen value.
+
+- When the `method` is `get`, you should return a value as `{rows: string[]}`.
+- Otherwise, you should return `{rows: string[][]}`.
+
 ```typescript copy
+import { drizzle } from 'drizzle-orm/sqlite-proxy';
+
 const db = drizzle(async (sql, params, method) => {
   try {
     const rows = await axios.post('http://localhost:3000/query', { sql, params, method });


### PR DESCRIPTION
Hi there.
Thank you, for an awesome library.

I'm developing Next.js apps on Stackblitz ordinarily and using Drizzle ORM with SQLite via Server Actions.

This works fine through HTTP-proxy callback, but the doc does not provides enough information to use HTTP proxy, I think.

I wrote additional information based on [README.md of drizzle-orm/examples/sqlite-proxy](https://github.com/drizzle-team/drizzle-orm/tree/main/examples/sqlite-proxy).

This information may prevent some developers stacks on same situation like me.

Best regards,

<!-- insert PR description above -->
-----
<a href="https://stackblitz.com/~/github/kedama-t/drizzle-orm-docs/tree/master"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz Codeflow" align="left" width="103" height="20"></a> _Submitted with [StackBlitz Codeflow](https://stackblitz.com/~/github/kedama-t/drizzle-orm-docs/tree/master)._