### PR TITLE
docs(node-postgres): Remove useless imports in docs example

### DIFF
--- a/pages/docs/quick-postgresql/node-postgres.mdx
+++ b/pages/docs/quick-postgresql/node-postgres.mdx
@@ -58,7 +58,6 @@ const db = drizzle(client);
 </Tab>
 <Tab>
 ```typescript copy filename="index.ts"
-import { pgTable, serial, text, varchar } from "drizzle-orm/pg-core";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
 


### PR DESCRIPTION
Removes useless imports in the docs, likely remaining from a copy paste