### PR TITLE
Update overview.mdx

### DIFF
--- a/pages/kit-docs/overview.mdx
+++ b/pages/kit-docs/overview.mdx
@@ -167,7 +167,7 @@ You can have autocomplete experience and a very convenient environment variables
 <CodeTabs items={["drizzle.config.ts", "drizzle.config.js", "drizzle.config.json"]}>
 <CodeTab>
 ```ts
-import { defineConfig } from 'drizzle-kit/utils'
+import { defineConfig } from 'drizzle-kit'
 
 export default defineConfig({
  schema: "./schema.ts",


### PR DESCRIPTION
when using the new way to define drizzle config, get error Cannot find module 'drizzle-kit/utils' or its corresponding type declarations.ts(2307) 

I don't know if defineConfig is supposed to be in drizzle-kit/utils but I get above error and removing utils and importing from drizzle-kit like before works