### PR TITLE
Add code for closing db connection in example

### DIFF
--- a/pages/kit-docs/overview.mdx
+++ b/pages/kit-docs/overview.mdx
@@ -131,6 +131,8 @@ const sql = postgres("...", { max: 1 })
 const db = drizzle(sql);
 
 await migrate(db, { migrationsFolder: "drizzle" });
+
+await sql.end();
 ```
 </Tab>
 <Tab>
@@ -143,6 +145,8 @@ const connection = createConnection("...")
 const db = drizzle(connection);
 
 await migrate(db, { migrationsFolder: "drizzle" });
+
+await connection.end();
 ```
 </Tab>
 <Tab>
@@ -155,6 +159,8 @@ const betterSqlite = new Database(":memory:");
 const db = drizzle(betterSqlite);
 
 migrate(db, { migrationsFolder: "drizzle" });
+
+betterSqlite.close()
 ```
 </Tab>
 </Tabs>

--- a/pages/kit-docs/quick.mdx
+++ b/pages/kit-docs/quick.mdx
@@ -124,6 +124,8 @@ const sql = postgres(connectionString, { max: 1 })
 const db = drizzle(sql);
 
 await migrate(db, { migrationsFolder: "drizzle" });
+
+await sql.end();
 ```
 
 That's it, folks!  


### PR DESCRIPTION
I encountered this [issue](https://github.com/drizzle-team/drizzle-orm/issues/1222) while setting up Drizzle based on the documentation. This PR adds code to close the connection after finishing migration for future readers.