### PR TITLE
Fix overview and detail pages about configuration of Drizzle Kit

### DIFF
--- a/pages/kit-docs/conf.mdx
+++ b/pages/kit-docs/conf.mdx
@@ -29,8 +29,6 @@ export default {
 </CodeTab>
 <CodeTab>
 ```js
-import type { Config } from "drizzle-kit";
-
 /** @type { import("drizzle-kit").Config } */
 export default {
   schema: "./src/schema.ts",

--- a/pages/kit-docs/overview.mdx
+++ b/pages/kit-docs/overview.mdx
@@ -182,8 +182,6 @@ export default {
 </CodeTab>
 <CodeTab>
 ```js
-import type { Config } from "drizzle-kit";
-
 /** @type { import("drizzle-kit").Config } */
 export default {
   schema: "./schema.ts",

--- a/pages/kit-docs/overview.mdx
+++ b/pages/kit-docs/overview.mdx
@@ -167,21 +167,23 @@ You can have autocomplete experience and a very convenient environment variables
 <CodeTabs items={["drizzle.config.ts", "drizzle.config.js", "drizzle.config.json"]}>
 <CodeTab>
 ```ts
-import { defineConfig } from 'drizzle-kit/utils'
+import { Config } from 'drizzle-kit';
 
-export default defineConfig({
+export default {
  schema: "./schema.ts",
   driver: 'pg',
   dbCredentials: {
-    connectionString: process.env.DB_URL,
+    connectionString: process.env.DB_URL ?? '',
   },
   verbose: true,
   strict: true,
-})
+} satisfies Config;
 ```
 </CodeTab>
 <CodeTab>
 ```js
+import type { Config } from "drizzle-kit";
+
 /** @type { import("drizzle-kit").Config } */
 export default {
   schema: "./schema.ts",


### PR DESCRIPTION
Pages [Overview](https://orm.drizzle.team/kit-docs/overview) and [Configuration](https://orm.drizzle.team/kit-docs/conf) are both showing config file examples.

However on the first page `import { defineConfig } from 'drizzle-kit/utils'` was used and on the second one `import { Config } from 'drizzle-kit';` was being used in the examples, while only `import { Config } from 'drizzle-kit';`, using the newer Typescript `satisfies` operator, works.

Therefore I have updated the docs to just show the examples in the correct form and in a consistent manner on both locations.