### PR TITLE
docs: add callouts to not use import aliases in schema files

### DIFF
--- a/pages/kit-docs/conf.mdx
+++ b/pages/kit-docs/conf.mdx
@@ -48,6 +48,10 @@ export default {
 </CodeTab>
 </CodeTabs>
 
+<Callout type="info" emoji="ℹ️">
+Make sure your schema file(s) aren't using import aliases like `@/users` or `~/users` because they can't be resolved by Drizzle Kit.
+</Callout>
+
 ## Schema files paths
 `schema` param lets you define where your schema file/files live.  
 

--- a/pages/kit-docs/config-reference.mdx
+++ b/pages/kit-docs/config-reference.mdx
@@ -72,6 +72,10 @@ export default {
 </Tab>
 </Tabs>
 
+<Callout type="info" emoji="ℹ️">
+Make sure your schema file(s) aren't using import aliases like `@/users` or `~/users` because they can't be resolved by Drizzle Kit.
+</Callout>
+
 ### out
 
 - **Type**: `string | string[]`

--- a/pages/kit-docs/overview.mdx
+++ b/pages/kit-docs/overview.mdx
@@ -164,6 +164,10 @@ Drizzle Kit lets you declare configurations in `TypeScript`, `JavaScript` or `JS
 
 You can have autocomplete experience and a very convenient environment variables flow!
 
+<Callout type="info" emoji="ℹ️">
+Make sure your schema file(s) aren't using import aliases like `@/users` or `~/users` because they can't be resolved by Drizzle Kit.
+</Callout>
+
 <CodeTabs items={["drizzle.config.ts", "drizzle.config.js", "drizzle.config.json"]}>
 <CodeTab>
 ```ts


### PR DESCRIPTION
Add callouts to not use import aliases in schema files:

<img width="896" alt="drizzle callout" src="https://github.com/drizzle-team/drizzle-orm-docs/assets/89942958/e0e4157c-803c-43a1-bb5b-c4ed5643b1aa">

<img width="875" alt="drizzle callout 2" src="https://github.com/drizzle-team/drizzle-orm-docs/assets/89942958/a7146d65-490e-4e4d-ac6c-e6dfe5f6dedd">

<img width="892" alt="drizzle callout 3" src="https://github.com/drizzle-team/drizzle-orm-docs/assets/89942958/c01f09db-3c54-40ff-88b1-151f896aaaeb">
