### PR TITLE
docs: fix typo in composite key description

### DIFF
--- a/src/content/documentation/docs/indexes-constraints.mdx
+++ b/src/content/documentation/docs/indexes-constraints.mdx
@@ -411,7 +411,7 @@ A table can have only **ONE** primary key; and in the table, this primary key ca
 
 ### Composite Primary Key
 
-Just like `PRIMARY KEY`, composite primary key uniquely each record in a table using multiple fields.
+Just like `PRIMARY KEY`, a composite primary key uniquely identifies each record in a table using multiple fields.
 
 Drizzle ORM provides a standalone `primaryKey` operator for that:
 <Tabs items={['PostgreSQL', 'MySQL', 'SQLite']}>


### PR DESCRIPTION
Follow up of #153
