### PR TITLE
Remove `await` from `getTableConfig(table)`

### DIFF
--- a/src/content/documentation/docs/goodies.mdx
+++ b/src/content/documentation/docs/goodies.mdx
@@ -331,7 +331,7 @@ very useful when you need to omit certain columns upon selection.
       primaryKeys,
       name,
       schema,
-    } = await getTableConfig(table);
+    } = getTableConfig(table);
     ```
   </Tab>
   <Tab>
@@ -348,7 +348,7 @@ very useful when you need to omit certain columns upon selection.
     primaryKeys,
     name,
     schema,
-  } = await getTableConfig(table);
+  } = getTableConfig(table);
   ```
   </Tab>
   <Tab>
@@ -365,7 +365,7 @@ very useful when you need to omit certain columns upon selection.
     primaryKeys,
     name,
     schema,
-  } = await getTableConfig(table);
+  } = getTableConfig(table);
   ```
   </Tab>
 </Tabs>


### PR DESCRIPTION
This is not async function.

See code for references:

- [MySQL](https://github.com/drizzle-team/drizzle-orm/blob/d20bd54cfbc7a8ead2b14eb24af7b73c752b80e2/drizzle-orm/src/mysql-core/utils.ts#L17)
- [PostgreSQL](https://github.com/drizzle-team/drizzle-orm/blob/d20bd54cfbc7a8ead2b14eb24af7b73c752b80e2/drizzle-orm/src/pg-core/utils.ts#L14)
- [SQLite](https://github.com/drizzle-team/drizzle-orm/blob/d20bd54cfbc7a8ead2b14eb24af7b73c752b80e2/drizzle-orm/src/sqlite-core/utils.ts#L17)