### PR TITLE
fix(docs): adjusting code examples

### DIFF
--- a/src/content/documentation/docs/indexes-constraints.mdx
+++ b/src/content/documentation/docs/indexes-constraints.mdx
@@ -692,7 +692,7 @@ To declare multicolumn foreign keys you can use a dedicated `foreignKey` operato
       lastName: text("lastName"),
     }, (table) => {
       return {
-        pk: primaryKey({ columns: [table.firstName, table.lastName]}),
+        pk: primaryKey({ columns: [table.firstName, table.lastName] }),
       };
     });
 
@@ -721,7 +721,7 @@ To declare multicolumn foreign keys you can use a dedicated `foreignKey` operato
       lastName: text("lastName"),
     }, (table) => {
       return {
-        pk: primaryKey({ columns: [table.firstName, table.lastName]}),
+        pk: primaryKey({ columns: [table.firstName, table.lastName] }),
       };
     });
 
@@ -750,7 +750,7 @@ To declare multicolumn foreign keys you can use a dedicated `foreignKey` operato
       lastName: text("lastName"),
     }, (table) => {
       return {
-        pk: primaryKey({ columns: [table.firstName, table.lastName]}),
+        pk: primaryKey({ columns: [table.firstName, table.lastName] }),
       };
     });
 

--- a/src/content/documentation/docs/rqb.mdx
+++ b/src/content/documentation/docs/rqb.mdx
@@ -270,7 +270,7 @@ export const usersToGroups = pgTable('users_to_groups', {
 		userId: integer('user_id').notNull().references(() => users.id),
 		groupId: integer('group_id').notNull().references(() => groups.id),
 	}, (t) => ({
-		pk: primaryKey(t.userId, t.groupId),
+		pk: primaryKey({ columns: [t.userId, t.groupId] }),
 	}),
 );
 
@@ -498,7 +498,7 @@ await db.query.users.findMany(...);
 		userId: integer('user_id').notNull().references(() => users.id),
 		groupId: integer('group_id').notNull().references(() => groups.id),
 	}, (t) => ({
-		pk: primaryKey(t.userId, t.groupId),
+		pk: primaryKey({ columns: [t.userId, t.groupId] }),
 	}));
 
 	export const usersToGroupsRelations = relations(usersToGroups, ({ one }) => ({


### PR DESCRIPTION
Adding spaces in some examples and adjusting deprecated examples

from: 

```ts
}, (t) => ({
  pk: primaryKey(t.userId, t.groupId),
}),
```

to: 

```ts
}, (t) => ({
  pk: primaryKey({ columns: [t.userId, t.groupId] }),
}),
```