### PR TITLE
docs: Suggest usage of Cloudflare Hyperdrive when using Postgres with Cloudflare Workers

### DIFF
--- a/src/content/documentation/docs/get-started-postgresql.mdx
+++ b/src/content/documentation/docs/get-started-postgresql.mdx
@@ -158,7 +158,7 @@ const db = drizzle(pool);
 
 ### Usage with Cloudflare Workers
 
-Now that Cloudflare Workers supports TCP connections, [you can use](https://developers.cloudflare.com/workers/databases/connect-to-postgres/) `node-postgres` to connect to connection poolers, e.g. pgBouncer.
+Now that Cloudflare Workers supports TCP connections, [you can use](https://developers.cloudflare.com/workers/databases/connect-to-postgres/) `node-postgres` to connect to connection poolers, e.g. **[Hyperdrive](https://developers.cloudflare.com/hyperdrive)**.
 
 ```typescript copy filename="worker.ts"
 import { Client } from "pg";


### PR DESCRIPTION
Updating tidbit about connection poolers with workers to mention cloudflare's own connection pooler instead of pgBouncer.