### PR TITLE
[PlanetScale] Update PlanetScale documentation

### DIFF
--- a/src/content/documentation/docs/get-started-mysql.mdx
+++ b/src/content/documentation/docs/get-started-mysql.mdx
@@ -28,17 +28,22 @@ drizzle-orm @planetscale/database
 
 ```typescript copy filename="index.ts"
 import { drizzle } from "drizzle-orm/planetscale-serverless";
-import { connect } from "@planetscale/database";
+import { Client } from "@planetscale/database";
 
 // create the connection
-const connection = connect({
+const client = new Client({
   host: process.env["DATABASE_HOST"],
   username: process.env["DATABASE_USERNAME"],
   password: process.env["DATABASE_PASSWORD"],
 });
 
-const db = drizzle(connection);
+...
+
+// Inside of your request handler, create a database instance
+const db = drizzle(client.connection());
 ```
+
+**NOTE**: You must create a fresh connection for each web request handler / transaction, as the database is executing requests over HTTP and is not meant to be shared globally.
 
 Make sure to checkout the PlanetScale official **[MySQL courses](https://planetscale.com/courses/mysql-for-developers/introduction/course-introduction)**, 
 we think they're outstanding 🙌

--- a/src/content/documentation/docs/get-started-mysql.mdx
+++ b/src/content/documentation/docs/get-started-mysql.mdx
@@ -30,7 +30,6 @@ drizzle-orm @planetscale/database
 import { drizzle } from "drizzle-orm/planetscale-serverless";
 import { Client } from "@planetscale/database";
 
-// create the connection
 const client = new Client({
   host: process.env["DATABASE_HOST"],
   username: process.env["DATABASE_USERNAME"],

--- a/src/content/documentation/docs/get-started-mysql.mdx
+++ b/src/content/documentation/docs/get-started-mysql.mdx
@@ -39,11 +39,8 @@ const client = new Client({
 
 ...
 
-// Inside of your request handler, create a database instance
-const db = drizzle(client.connection());
+const db = drizzle(client);
 ```
-
-**NOTE**: You must create a fresh connection for each web request handler / transaction, as the database is executing requests over HTTP and is not meant to be shared globally.
 
 Make sure to checkout the PlanetScale official **[MySQL courses](https://planetscale.com/courses/mysql-for-developers/introduction/course-introduction)**, 
 we think they're outstanding 🙌

--- a/src/content/documentation/docs/get-started-mysql.mdx
+++ b/src/content/documentation/docs/get-started-mysql.mdx
@@ -37,8 +37,6 @@ const client = new Client({
   password: process.env["DATABASE_PASSWORD"],
 });
 
-...
-
 const db = drizzle(client);
 ```
 


### PR DESCRIPTION
The way the documentation exists now, it suggests using a global connection for the database driver. In reality, this can lead to data inconsistencies as this connection is not meant to be shared across requests. This updates the documentation to use `Client` in the instantiation, because `execute` within `Client` will spawn a fresh connection each time and it also properly handles transactions as well.

See https://github.com/drizzle-team/drizzle-orm/issues/1743#issuecomment-1892634033 for more information.

This PR is in draft mode until we ensure that we can get the code changes working as well, because I believe it expects a `Connection` right now.