### PR TITLE
rewrite `bun:sqlite` examples to `bun@1.0.23`

### DIFF
--- a/src/content/documentation/docs/get-started-sqlite.mdx
+++ b/src/content/documentation/docs/get-started-sqlite.mdx
@@ -136,9 +136,8 @@ drizzle-orm
 
 ```typescript copy
 import { drizzle } from 'drizzle-orm/bun-sqlite';
-import { Database } from 'bun:sqlite';
+import sqlite from "./sqlite.db" with { type: "sqlite" };
 
-const sqlite = new Database('sqlite.db');
 const db = drizzle(sqlite);
 
 const result = await db.select().from(users);


### PR DESCRIPTION
`bun@1.0.23` intoduced a new ES Module style for improting sqlite databases.

More info: 
https://bun.sh/blog/bun-v1.0.23#import-sqlite-databases-in-bun
https://bun.sh/docs/api/sqlite#load-via-es-module-import