### PR TITLE
docs(insert): Explain how to get the entryId after INSERT

### DIFF
--- a/src/content/documentation/docs/insert.mdx
+++ b/src/content/documentation/docs/insert.mdx
@@ -38,6 +38,14 @@ await db.insert(users).values({ name: "Dan" }).returning();
 await db.insert(users).values({ name: "Partial Dan" }).returning({ insertedId: users.id });
 ```
 
+### Getting the inserted id
+<IsSupportedChipGroup chips={{ 'PostgreSQL': true, 'SQLite': true, 'MySQL': true }} />
+After inserting a row, you can get the id of the new entry like this:
+```typescript copy
+const insertResult = await db.insert(users).values({ name: "Dan" }).returning();
+const newUserId = insertResult.insertId
+```
+
 ## Insert multiple rows
 ```typescript copy
 await db.insert(users).values([{ name: 'Andrew' }, { name: 'Dan' }]);


### PR DESCRIPTION
In the docs, it looks like it's not possible to get the ID if you're using MySQL, but that is not true.

Nowhere is mentioned how to use the `insertId` property, this is where I would expect to find it.