### PR TITLE
fix: prevent overriding browser shortcuts (cmd 1, cmd 2, cmd 3)

### DIFF
--- a/src/components/layout/LogoDocs.astro
+++ b/src/components/layout/LogoDocs.astro
@@ -350,7 +350,7 @@ const condition = isDocs
     : 0;
 
   window.addEventListener("keydown", (e) => {
-    if (e.key === "1" || e.key === "2" || e.key === "3") {
+    if (!e.metaKey && (e.key === "1" || e.key === "2" || e.key === "3")) {
       e.preventDefault();
       if (sectionSelectorItems && sectionSelector && currentSectionNum) {
         pos = +e.key - 1;


### PR DESCRIPTION
I (and other people probably) like to do `cmd` `1`, `cmd` `2`, `cmd` `3`, etc to go to my first/second/third browser tab, but right now the `1`, `2`,  and `3` shortcuts on the docs are preventing those browser shortcuts. This PR should fix that by adding the condition `!e.metaKey`.