### PR TITLE
Disable swticher when MetaKey is pressed

### DIFF
--- a/src/components/layout/LogoDocs.astro
+++ b/src/components/layout/LogoDocs.astro
@@ -350,7 +350,7 @@ const condition = isDocs
     : 0;
 
   window.addEventListener("keydown", (e) => {
-    if (e.key === "1" || e.key === "2" || e.key === "3") {
+    if (!e.metaKey && (e.key === "1" || e.key === "2" || e.key === "3")) {
       e.preventDefault();
       if (sectionSelectorItems && sectionSelector && currentSectionNum) {
         pos = +e.key - 1;


### PR DESCRIPTION
The docs switcher is great, but when using the browser shortcut to switch tabs (⌘ + 1,2,3) on the  docs, it overtakes the shortcut. Looks like it was only supposed to be done on plain 1,2,3 keys, so it's an easy fix to check for ⌘