### PR TITLE
fix: update many-to-many primary key syntax

### DIFF
--- a/src/content/documentation/docs/rqb.mdx
+++ b/src/content/documentation/docs/rqb.mdx
@@ -269,8 +269,8 @@ export const groupsRelations = relations(groups, ({ many }) => ({
 export const usersToGroups = pgTable('users_to_groups', {
 		userId: integer('user_id').notNull().references(() => users.id),
 		groupId: integer('group_id').notNull().references(() => groups.id),
-	}, (t) => ({
-		pk: primaryKey(t.userId, t.groupId),
+	}, (table) => ({
+		pk: primaryKey({ columns: [table.userId, table.groupId] }),
 	}),
 );
 
@@ -497,8 +497,8 @@ await db.query.users.findMany(...);
 		id: serial('id').primaryKey(),
 		userId: integer('user_id').notNull().references(() => users.id),
 		groupId: integer('group_id').notNull().references(() => groups.id),
-	}, (t) => ({
-		pk: primaryKey(t.userId, t.groupId),
+	}, (table) => ({
+		pk: primaryKey({ columns: [table.userId, table.groupId] }),
 	}));
 
 	export const usersToGroupsRelations = relations(usersToGroups, ({ one }) => ({


### PR DESCRIPTION
Updates the code examples in `rqb.md` to use the new primary key syntax 

