### PR TITLE
fix: text width for callouts

### DIFF
--- a/src/components/layout/GlobalStyles.astro
+++ b/src/components/layout/GlobalStyles.astro
@@ -497,7 +497,6 @@
   .callout-content {
     line-height: 1.75rem;
     min-width: 0;
-    width: 100%;
   }
 
   .callout-content p {


### PR DESCRIPTION
This PR fixes this weird layout shift
![image](https://github.com/drizzle-team/drizzle-orm-docs/assets/102473837/9d508fbe-9d46-477a-969e-9dbb9ed43cb3)

with this
![image](https://github.com/drizzle-team/drizzle-orm-docs/assets/102473837/039cee08-0ce1-4fa9-bc5a-a6913733ddfd)

I have tested this for both mobile, desktop and other layouts and it is responsive now.