### PR TITLE
Update config-reference.mdx

### DIFF
--- a/src/content/documentation/kit-docs/config-reference.mdx
+++ b/src/content/documentation/kit-docs/config-reference.mdx
@@ -17,7 +17,7 @@ Here are some examples of each file format usage:
 
 **Typescript example**
 ```ts
-import { defineConfig } from 'drizzle-kit/utils'
+import { defineConfig } from 'drizzle-kit'
 
 export default defineConfig({
   schema: "./schema.ts",


### PR DESCRIPTION
Removed `/utils` suffix from defineConfig import as it is incorrect. Similar as https://github.com/drizzle-team/drizzle-orm-docs/pull/159