### PR TITLE
fix: usersTable to users

### DIFF
--- a/src/content/documentation/docs/select.mdx
+++ b/src/content/documentation/docs/select.mdx
@@ -271,9 +271,9 @@ select "id", "name", "age" from "users" where "id" = 42 or "name" = 'Dan';
 You can use `.selectDistinct()` instead of `.select()` to retrieve only unique rows from a dataset:
 <Section>
 ```ts
-await db.selectDistinct().from(users).orderBy(usersTable.id, usersTable.name);
+await db.selectDistinct().from(users).orderBy(users.id, users.name);
 
-await db.selectDistinct({ id: users.id }).from(users).orderBy(usersTable.id);
+await db.selectDistinct({ id: users.id }).from(users).orderBy(users.id);
 ```
 ```sql
 select distinct "id", "name" from "users" order by "id", "name";


### PR DESCRIPTION
In the `selectDistinct` docs, the example users both "users" and "usersTables" in the same line.

To keep this consistent with other examples, this commit chooses "users"