### PR TITLE
DOCS: added "--config" as valid parameter for drizzle studio

### DIFF
--- a/src/content/documentation/kit-docs/commands.mdx
+++ b/src/content/documentation/kit-docs/commands.mdx
@@ -312,6 +312,7 @@ $ drizzle-kit check:pg --out=drizzle
 | param     | required | description              |
 | :-------- | :------- | :----------------------- |
 | `port`    | no       | custom port              |
+| `config`  | no       | path to custom config    |
 | `verbose` | no       | log all sql statements   |
 
 ```bash


### PR DESCRIPTION
Added for the following page the "--config" parameter as a valid option.

https://orm.drizzle.team/kit-docs/commands#drizzle-studio-new