### PR TITLE
fix: missing id param in function example in code example

### DIFF
--- a/src/content/tutorials/drizzle-with-frameworks/drizzle-nextjs-neon.mdx
+++ b/src/content/tutorials/drizzle-with-frameworks/drizzle-nextjs-neon.mdx
@@ -498,11 +498,11 @@ export const getData = async () => {
   return data;
 };
 
-export const addTodo = async (text: string) => {
+export const addTodo = async (id: number, text: string) => {
   await db.insert(todo).values({
+    id: id,
     text: text,
   });
-  revalidatePath("/");
 };
 
 export const deleteTodo = async (id: number) => {


### PR DESCRIPTION
In the docs, there is an piece of code that shows the following:
```js
export const addTodo = async (id: number, text: string) => {
  await db.insert(todo).values({
    id: id,
    text: text,
  });
};
```
But at in the end, in the topic: "Establish server-side functions", it was wrong, because the functions didn't provided the function param to pass the id, causing a type error in typescript.

The code now fix that error.