### PR TITLE
docs: fix a grammatical typo in get-started-sqlite.mdx

### DIFF
--- a/src/content/documentation/docs/get-started-sqlite.mdx
+++ b/src/content/documentation/docs/get-started-sqlite.mdx
@@ -125,7 +125,7 @@ According to the **[official website](https://bun.sh/)**, Bun is a fast all-in-o
 
 Drizzle ORM natively supports **[`bun:sqlite`](https://bun.sh/docs/api/sqlite)** module and it's crazy fast 🚀  
 
-We embraces SQL dialects and dialect specific drivers and syntax and unlike any other ORM, 
+We embrace SQL dialects and dialect specific drivers and syntax and unlike any other ORM, 
 for synchronous drivers like `bun:sqlite` we have both **async** and **sync** APIs and we mirror most popular 
 SQLite-like `all`, `get`, `values` and `run` query methods syntax.
 


### PR DESCRIPTION
> We embraces SQL dialects and dialect specific drivers

changed to "We embrace..."