### PR TITLE
Add pglite to anchorcards in get-started-postgresql

### DIFF
--- a/src/content/documentation/docs/get-started-postgresql.mdx
+++ b/src/content/documentation/docs/get-started-postgresql.mdx
@@ -8,6 +8,7 @@ import AnchorCards from '@components/markdown/AnchorCards.astro';
 <AnchorCards cards={{
   "Neon": "#neon",
   "Xata": "#xata",
+  "PGlite": "#pglite",
   "Postgres.JS": "#postgresjs",
   "node-postgres": "#node-postgres",
   "Vercel Postgres" : "#vercel-postgres",


### PR DESCRIPTION
Added PGlite link to the table at the top of the get-started-postgresql page.