### PR TITLE
fix: incorrect type declaration

### DIFF
--- a/src/content/documentation/docs/joins.mdx
+++ b/src/content/documentation/docs/joins.mdx
@@ -245,8 +245,8 @@ Drizzle ORM delivers name-mapped results from the driver without changing the st
 
 You're free to operate with results the way you want, here's an example of mapping many-one relational data:
 ```typescript
-type User = typeof usersTable.$inferSelect;
-type Pet = typeof usersTable.$inferSelect;
+type User = typeof users.$inferSelect;
+type Pet = typeof pets.$inferSelect;
 
 const rows = db.select({
     user: users,


### PR DESCRIPTION
Hello ! As I was reading examples about joins [in here](https://orm.drizzle.team/docs/joins#joins-sql), I found an inconsistent type declaration and thought I would go ahead and propose a fix :) Thank you for all your hard work. 

-----
<a href="https://stackblitz.com/~/github.com/epaumier/drizzle-orm-docs/tree/epaumier/patch-65137"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz" align="left" width="103" height="20"></a> _Submitted with [StackBlitz](https://stackblitz.com/~/github.com/epaumier/drizzle-orm-docs/tree/epaumier/patch-65137)._