### PR TITLE
docs: corrected key name in `varchar` example

### DIFF
--- a/src/content/documentation/docs/column-types/pg.mdx
+++ b/src/content/documentation/docs/column-types/pg.mdx
@@ -267,7 +267,7 @@ import { varchar, pgTable } from "drizzle-orm/pg-core";
 
 export const table = pgTable('table', {
   varchar1: varchar('varchar1'),
-  varchar1: varchar('varchar2', { length: 256 }),
+  varchar2: varchar('varchar2', { length: 256 }),
 });
 
 // will be inferred as text: "value1" | "value2" | null


### PR DESCRIPTION
Both keys in `varchar` example were erroneously named `varchar1`. Changed second key to `varchar2`.