### PR TITLE
docs: Updated Cloudflare D1 example to use wrangler's migrations API

### DIFF
--- a/src/content/documentation/docs/get-started-sqlite.mdx
+++ b/src/content/documentation/docs/get-started-sqlite.mdx
@@ -74,11 +74,12 @@ node_compat = true
 binding = "DB"
 database_name = "YOUR DB NAME"
 database_id = "YOUR DB ID"
+migrations_dir = "drizzle/migrations"
 ```
 
 Initialize local database and run server locally:
 ```bash
-wrangler d1 execute <DATABASE_NAME> --local --file=./drizzle/0000_short_lockheed.sql
+wrangler d1 migrations apply <DATABASE_NAME> --local
 wrangler dev ## on wrangler versions below 3.0.0, add the --local and --persist flags
 ```
 


### PR DESCRIPTION
Related to https://github.com/drizzle-team/drizzle-orm/pull/2357

```
Update the D1 example to use Wrangler's D1 migrations API instead of executing individual commands for each file.
```