### PR TITLE
fix: missing comma on upgrade

### DIFF
--- a/src/content/documentation/kit-docs/upgrade-21.mdx
+++ b/src/content/documentation/kit-docs/upgrade-21.mdx
@@ -15,7 +15,7 @@ import { defineConfig } from "drizzle-kit"
 
 export default defineConfig({
     dialect: "sqlite", // "postgresql" | "mysql"
-    driver: "turso" // optional and used only if `aws-data-api`, `turso`, `d1-http`(WIP) or `expo` are used
+    driver: "turso", // optional and used only if `aws-data-api`, `turso`, `d1-http`(WIP) or `expo` are used
     dbCredentials: {
         url: ""
     }


### PR DESCRIPTION
A little fix on the "upgrading to `v0.21.0`" file because are missing a comma on the config object example.

![CleanShot 2024-05-27 at 11 33 52](https://github.com/drizzle-team/drizzle-orm-docs/assets/62335491/9cf6377f-f114-45d1-9171-5b1cf13b91e0)

