### PR TITLE
fix postgres typo in docs/rqb.mdx

### DIFF
--- a/src/content/documentation/docs/rqb.mdx
+++ b/src/content/documentation/docs/rqb.mdx
@@ -354,7 +354,7 @@ export const profileInfo = pgTable('profile_info', {
 
 ### Foreign key actions
 
-for more information check [posrgres foreign keys docs](https://www.postgresql.org/docs/current/ddl-constraints.html#DDL-CONSTRAINTS-FK)
+for more information check [postgres foreign keys docs](https://www.postgresql.org/docs/current/ddl-constraints.html#DDL-CONSTRAINTS-FK)
 
 You can specify actions that should occur when the referenced data in the parent table is modified. These actions are known as "foreign key actions." PostgreSQL provides several options for these actions.
 


### PR DESCRIPTION
Just a little typo fix that I noticed while reading the docs.