### PR TITLE
fix: apply corrections to edge docs for vercel/neon

### DIFF
--- a/src/content/tutorials/drizzle-on-the-edge/drizzle-with-vercel-edge-functions.mdx
+++ b/src/content/tutorials/drizzle-on-the-edge/drizzle-with-vercel-edge-functions.mdx
@@ -32,10 +32,10 @@ drizzle-orm
 
 When using Drizzle ORM with Vercel Edge functions you have to use edge-compatible drivers because the functions run in [Edge runtime](https://vercel.com/docs/functions/runtimes/edge-runtime) not in Node.js runtime, so there are some limitations of standard Node.js APIs.
 
-You can choose on of these drivers according to your database dialect:
+You can choose one of these drivers according to your database dialect:
 
-- [Neon serverless driver](/docs/get-started-postgresql#neon) allows you access any `PostgreSQL` client and query data from serverless and edge environments over HTTP or WebSockets in place of TCP. We recommend using this driver for `non-Vercel Postgres` client because Vercel Postgres driver implements specific connection string checks that may not be compatible with other `PostgreSQL` clients.
-- [Vercel Postgres driver](/docs/get-started-postgresql#vercel-postgres) is built on top of the `Neon serverless driver` and allows you access any `PostgreSQL` client. We recommend using this driver for `Vercel Postgres` client.
+- [Neon serverless driver](/docs/get-started-postgresql#neon) allows you to query your Neon Postgres databases from serverless and edge environments over HTTP or WebSockets in place of TCP. We recommend using this driver for connecting to `Neon Postgres`.
+- [Vercel Postgres driver](/docs/get-started-postgresql#vercel-postgres) is built on top of the `Neon serverless driver`. We recommend using this driver for connecting to `Vercel Postgres`.
 - [PlanetScale serverless driver](/docs/get-started-mysql#planetscale) allows you access any `MySQL` client and execute queries over an HTTP connection, which is generally not blocked by cloud providers.
 - [libSQL client](/docs/get-started-sqlite#turso) allows you to access [Turso](https://docs.turso.tech/introduction) database.
 
@@ -47,8 +47,6 @@ You can choose on of these drivers according to your database dialect:
 - Navigate directly to the [Turso](/learn/tutorials/drizzle-with-vercel-edge-functions#turso) section.
 
 ### Any PostgreSQL client
-
-In this tutorial we use [Supabase PostgreSQL](https://supabase.com/docs/guides/database/overview) to demonstrate that any `PostgreSQL` client can be used with the Neon serverless driver and Vercel Edge functions.
 
 <Steps>
 #### Setup Drizzle config file
@@ -72,7 +70,7 @@ export default defineConfig({
 Configure your database connection string in the `.env` file:
 
 ```plaintext filename=".env"
-POSTGRES_URL="postgres://[user].xyejfgcvritnursacipt:[password]@aws-0-[region].pooler.supabase.com:6543/[db-name]"
+POSTGRES_URL="postgres://[user]:[password]@[host]-[region].aws.neon.tech:5432/[db-name]?sslmode=[ssl-mode]"
 ```
 
 #### Create a table


### PR DESCRIPTION
This corrects the statement that Neon's serverless driver is compatible with any Postgres provider. The serverless driver is only compatible with environments where Neon's HTTP/WebSocket proxy is deployed in front of Postgres.