### PR TITLE
Fix self-join example in documentation

### DIFF
--- a/src/content/documentation/docs/joins.mdx
+++ b/src/content/documentation/docs/joins.mdx
@@ -208,10 +208,10 @@ const parent = alias(user, "parent")
 const result = db
   .select()
   .from(user)
-  .leftJoin(parent, eq(parent.id, user.id));
+  .leftJoin(parent, eq(parent.id, user.parentId));
 ```
 ```sql
-select ... from "user" left join "user" "parent" on "parent"."id" = "user"."id"
+select ... from "user" left join "user" "parent" on "parent"."id" = "user"."parent_id"
 ```
 ```typescript
 // result type


### PR DESCRIPTION
This PR fixes the self-join example in the documentation.

- Corrected the self-join example to use `user.parentId` instead of `user.id` for the join condition.