### PR TITLE
fix: Incorrect documentation for usage of tx.rollback()

### DIFF
--- a/src/content/documentation/docs/transactions.mdx
+++ b/src/content/documentation/docs/transactions.mdx
@@ -35,14 +35,14 @@ await db.transaction(async (tx) => {
 
 You can embed business logic to the transaction and rollback whenever needed:
 
-```ts copy {6}
+```ts copy {7}
 const db = drizzle(...)
 
 await db.transaction(async (tx) => {
   const [account] = await tx.select({ balance: accounts.balance }).from(accounts).where(eq(users.name, 'Dan'));
   if (account.balance < 100) {
-    await tx.rollback()
-    return
+    // This throws an exception that rollbacks the transaction.
+    tx.rollback()
   }
 
   await tx.update(accounts).set({ balance: sql`${accounts.balance} - 100.00` }).where(eq(users.name, 'Dan'));


### PR DESCRIPTION
The type signature for `tx.rollback()` is `(void) => never` because the expected behavior is that calling this method throws an error that causes the driver to rollback the transaction.

The example as is currently written contradicts this expectation. The `await` in the example implies that `tx.rollback()` returns a promise that must be awaited. Not only does TypeScript flag this as an issue 
```
typescript: 'await' has no effect on the type of this expression
```
but in correctly using rollback in a non-async function would cause an application to crash e.g. uncaught promise error.

This update removes the await keyword and adds a comment indicating the expected behavior.
