### PR TITLE
Correct alias reference to aliasedTable

### DIFF
--- a/src/content/documentation/docs/joins.mdx
+++ b/src/content/documentation/docs/joins.mdx
@@ -204,7 +204,7 @@ Lets say you need to fetch users with their parents:
 ```typescript copy
 import { user } from "./schema";
 
-const parent = alias(user, "parent")
+const parent = aliasedTable(user, "parent")
 const result = db
   .select()
   .from(user)


### PR DESCRIPTION
`joins.mdx` reference an `alias` function which isn't exported from `drizzle-orm`, replace with `aliasedTable` instead.