### PR TITLE
Fixed the example of using the 'schema' property with drizzle-graphql…

### DIFF
--- a/src/content/documentation/docs/graphql.mdx
+++ b/src/content/documentation/docs/graphql.mdx
@@ -23,12 +23,13 @@ Make sure your `drizzle-orm` version is at least `0.30.9`, and update if needed:
 ```ts copy {1, 10}
 import { buildSchema } from 'drizzle-graphql';
 import { drizzle } from 'drizzle-orm/...';
+import client from './db';
 import { ApolloServer } from '@apollo/server';
 import { startStandaloneServer } from '@apollo/server/standalone';
 
 import * as dbSchema from './schema';
 
-const db = drizzle({ schema: dbSchema });
+const db = drizzle(client, { schema: dbSchema });
 
 const { schema } = buildSchema(db);
 


### PR DESCRIPTION
I spent a considerable amount of time understanding that the schema property is the second parameter of the drizzle method. I took the liberty of updating the documentation to make this more evident. Regardless of whether this pull request is approved or not, I strongly suggest this adjustment in the documentation.

By the way, congratulations on the great work.