### PR TITLE
docs: add relation in one-to-one example

### DIFF
--- a/src/content/documentation/docs/rqb.mdx
+++ b/src/content/documentation/docs/rqb.mdx
@@ -169,6 +169,10 @@ export const profileInfo = pgTable('profile_info', {
 	metadata: jsonb('metadata'),
 });
 
+export const profileInfoRelations = relations(profileInfo, ({ one }) => ({
+	user: one(users, { fields: [profileInfo.userId], references: [users.id] }),
+}));
+
 const user = await queryUserWithProfileInfo();
 //____^? type { id: number, profileInfo: { ... } | null  }
 ```


### PR DESCRIPTION
Fixes https://github.com/drizzle-team/drizzle-orm-docs/issues/335

Would be nice if the following elements are documented as well:

## One-to-one relation in a separate table

- `one` relations must be defined on both tables.
- `fields` and `references` should be defined on one side.
- `fields` and `references` changes if the queried result is nullable:

```ts
const profileInfo = await queryProfileInfoWithUser();
//____^? type { id: number, user: { ... }  }
```