### PR TITLE
Add more detail to what the keys and values of the update object can be

### DIFF
--- a/src/content/documentation/docs/update.mdx
+++ b/src/content/documentation/docs/update.mdx
@@ -10,6 +10,16 @@ await db.update(users)
   .where(eq(users.name, 'Dan'));
 ```
 
+The object that you pass to `update` should have keys that match column names in your database schema.
+Values of `undefined` are ignored in the object: to set a column to `null`, pass `null`.
+You can pass SQL as a value to be used in the update object, like this:
+
+```typescript copy
+await db.update(users)
+  .set({ updatedAt: sql`NOW()` })
+  .where(eq(users.name, 'Dan'));
+```
+
 ### Update with returning
 <IsSupportedChipGroup chips={{ 'PostgreSQL': true, 'SQLite': true, 'MySQL': false }} />
 You can update a row and get it back in PostgreSQL and SQLite:


### PR DESCRIPTION
I couldn't remember offhand today whether passing `undefined` within an update object would do nothing, set the column to null, or create some error. Confirmed the behavior with the code but wanted to update the docs for future people who wonder.