### PR TITLE
Fix typo in column type docs

### DIFF
--- a/src/content/documentation/docs/column-types/pg.mdx
+++ b/src/content/documentation/docs/column-types/pg.mdx
@@ -267,7 +267,7 @@ import { varchar, pgTable } from "drizzle-orm/pg-core";
 
 export const table = pgTable('table', {
   varchar1: varchar('varchar1'),
-  varchar1: varchar('varchar2', { length: 256 }),
+  varchar2: varchar('varchar2', { length: 256 }),
 });
 
 // will be inferred as text: "value1" | "value2" | null


### PR DESCRIPTION
In the example on the `varchar` column type for Postgres, you are defining two columns with the same name. This change fixes the naming to not be duplicated.