### PR TITLE
docs: Remove erroneous '2' in join statement example

### DIFF
--- a/src/content/documentation/docs/joins.mdx
+++ b/src/content/documentation/docs/joins.mdx
@@ -296,7 +296,7 @@ const users = sqliteTable('users', {
 
 const db = drizzle(sqlite);
 
-const result = db.select().from(cities).leftJoin(users, eq(cities2.id, users2.cityId)).all();
+const result = db.select().from(cities).leftJoin(users, eq(cities.id, users.cityId)).all();
 ```
 ## Many-to-many example
 ```typescript


### PR DESCRIPTION
There is unnecessary '2' written at the end of tables name in examples for one to many joins.