### PR TITLE
Update indexes-constraints.mdx

### DIFF
--- a/src/content/documentation/docs/indexes-constraints.mdx
+++ b/src/content/documentation/docs/indexes-constraints.mdx
@@ -760,11 +760,11 @@ To declare multicolumn foreign keys you can use a dedicated `foreignKey` operato
       userLastName: text("user_last_name"),
     }, (table) => {
       return {
-        userReference: foreignKey(() => ({
+        userReference: foreignKey({
           columns: [table.userFirstName, table.userLastName],
           foreignColumns: [user.firstName, user.lastName],
           name: "custom_name"
-        }))
+        })
       }
     });
     ```


### PR DESCRIPTION
Update sqlite multicolumn foreign keys example to not use deprecated function signature (passing callback) for `foreignKey`