### PR TITLE
Remove unused pg-core imports

### DIFF
--- a/src/content/documentation/docs/get-started-postgresql.mdx
+++ b/src/content/documentation/docs/get-started-postgresql.mdx
@@ -213,7 +213,6 @@ You can connect to a PostgreSQL database either using a single `client` connecti
 <Tabs items={['Client connection', 'Pool connection']}>
   <Tab>
 ```typescript copy filename="index.ts"
-import { pgTable, serial, text, varchar } from "drizzle-orm/pg-core";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Client } from "pg";
 
@@ -236,7 +235,6 @@ const db = drizzle(client);
 </Tab>
 <Tab>
 ```typescript copy filename="index.ts"
-import { pgTable, serial, text, varchar } from "drizzle-orm/pg-core";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
 


### PR DESCRIPTION
Imports from "drizzle-orm/pg-core" are not used in the following code and should be removed from examples.