### PR TITLE
docs(Expo SQLite): fix js copy filename

### DIFF
--- a/src/content/documentation/docs/get-started/expo-new.mdx
+++ b/src/content/documentation/docs/get-started/expo-new.mdx
@@ -122,7 +122,7 @@ module.exports = config;
 ```
 
 #### Step 7 - Update `babel` config
-```js copy filename="metro.config.js"
+```js copy filename="babel.config.js"
 module.exports = function(api) {
   api.cache(true);
   return {


### PR DESCRIPTION
Fixing typos, should be babel.config.js instead of metro.config.js