### PR TITLE
typo fix in migrations.mdx, scheama -> schema

### DIFF
--- a/src/content/documentation/docs/migrations.mdx
+++ b/src/content/documentation/docs/migrations.mdx
@@ -161,7 +161,7 @@ export const users = p.pgTable("users", {
 └─┬──────────────────────┘                  
   │                                           
   └ 1. read previous migration folders
-    2. find diff between current and previous scheama
+    2. find diff between current and previous schema
     3. prompt developer for renames if necessary
   ┌ 4. generate SQL migration and persist to file
   │    ┌─┴───────────────────────────────────────┐  
@@ -229,7 +229,7 @@ export const users = p.pgTable("users", {
 └─┬──────────────────────┘                  
   │                                           
   └ 1. read previous migration folders
-    2. find diff between current and previous scheama
+    2. find diff between current and previous schema
     3. prompt developer for renames if necessary
   ┌ 4. generate SQL migration and persist to file
   │    ┌─┴───────────────────────────────────────┐  


### PR DESCRIPTION
fixed typo in migrations.mdx