### PR TITLE
Fixed migrations docs for Option 4 migration scenario

### DIFF
--- a/src/content/documentation/docs/migrations.mdx
+++ b/src/content/documentation/docs/migrations.mdx
@@ -250,7 +250,8 @@ CREATE TABLE "users" (
 ```
 ```ts
 // index.ts
-import { drizzle, migrate } from "drizzle-orm/node-postgres"
+import { drizzle } from "drizzle-orm/node-postgres"
+import { migrate } from 'drizzle-orm/node-postgres/migrator';
 
 const db = drizzle(process.env.DATABASE_URL);
 


### PR DESCRIPTION
`migrate` method is not exposed as a part of`drizzle-orm/node-postgres`

ref - https://github.com/drizzle-team/drizzle-orm/blob/526996bd2ea20d5b1a0d65e743b47e23329d441c/drizzle-orm/src/node-postgres/index.ts