### PR TITLE
fix: update dialect for turso tutorial

### DIFF
--- a/src/content/documentation/docs/tutorials/drizzle-with-db/drizzle-with-turso.mdx
+++ b/src/content/documentation/docs/tutorials/drizzle-with-db/drizzle-with-turso.mdx
@@ -151,8 +151,7 @@ config({ path: '.env' });
 export default defineConfig({
   schema: './src/db/schema.ts',
   out: './migrations',
-  dialect: 'sqlite',
-  driver: 'turso',
+  dialect: 'turso',
   dbCredentials: {
     url: process.env.TURSO_CONNECTION_URL!,
     authToken: process.env.TURSO_AUTH_TOKEN!,


### PR DESCRIPTION
I was getting errors with the existing code snippet.

The first error was a zod validation because `turso` is not a valid driver.

After removing the driver config line, I was getting a type error with sqlite as the dialect because it expects the token config to be a `token` prop instead of `authToken`.

After digging into the source code and identifying the `Dialect` type, it seems that the proper value for dialect is `turso`.