### PR TITLE
Fixed incorrect import for AWS RDS

### DIFF
--- a/src/content/docs/connect-aws-data-api-pg.mdx
+++ b/src/content/docs/connect-aws-data-api-pg.mdx
@@ -22,7 +22,7 @@ drizzle-orm @aws-sdk/client-rds-data
 
 #### Step 2 - Initialize the driver and make a query
 ```typescript copy
-import { drizzle } from 'drizzle-orm/aws-data-api-pg';
+import { drizzle } from 'drizzle-orm/aws-data-api/pg';
 
 // These three properties are required. You can also specify
 // any property from the RDSDataClient type inside the connection object.


### PR DESCRIPTION
Quick fix. It's supposed to be a `/` not a `-`.