### PR TITLE
Update docs for validator libraries

### DIFF
--- a/src/content/docs/typebox.mdx
+++ b/src/content/docs/typebox.mdx
@@ -1,7 +1,7 @@
 import Npm from '@mdx/Npm.astro';
+import Callout from '@mdx/Callout.astro';
 
 # drizzle-typebox
-
 
 `drizzle-typebox` is a plugin for **[Drizzle ORM](https://github.com/drizzle-team/drizzle-orm)** that allows you to generate **[Typebox](https://github.com/sinclairzx81/typebox)** schemas from Drizzle ORM schemas.
 
@@ -11,44 +11,499 @@ import Npm from '@mdx/Npm.astro';
 drizzle-typebox
 </Npm>
 
-    # Usage
+<Callout type="warning">
+You must also have Drizzle ORM v0.36.0 or greater and Typebox v0.34.8 or greater installed.
+</Callout>
 
-    ```ts
-    import { pgEnum, pgTable, serial, text, timestamp } from 'drizzle-orm/pg-core';
-    import { createInsertSchema, createSelectSchema } from 'drizzle-typebox';
-    import { Type } from '@sinclair/typebox';
-    import { Value } from '@sinclair/typebox/value';
+### Select schema
 
-    const users = pgTable('users', {
-        id: serial('id').primaryKey(),
-        name: text('name').notNull(),
-        email: text('email').notNull(),
-        role: text('role', { enum: ['admin', 'user'] }).notNull(),
-        createdAt: timestamp('created_at').notNull().defaultNow(),
-    });
+Defines the shape of data queried from the database - can be used to validate API responses.
 
-    // Schema for inserting a user - can be used to validate API requests
-    const insertUserSchema = createInsertSchema(users);
+```ts copy
+import { pgTable, text, integer } from 'drizzle-orm/pg-core';
+import { createSelectSchema } from 'drizzle-typebox';
+import { Value } from '@sinclair/typebox/value';
 
-    // Schema for selecting a user - can be used to validate API responses
-    const selectUserSchema = createSelectSchema(users);
+const users = pgTable('users', {
+  id: integer().generatedAlwaysAsIdentity().primaryKey(),
+  name: text().notNull(),
+  age: integer().notNull()
+});
 
-    // Overriding the fields
-    const insertUserSchema = createInsertSchema(users, {
-        role: Type.String(),
-    });
+const userSelectSchema = createSelectSchema(users);
 
-    // Refining the fields - useful if you want to change the fields before they become nullable/optional in the final schema
-    const insertUserSchema = createInsertSchema(users, {
-        id: (schema) => Type.Number({ minimum: 0 }),
-        role: Type.String(),
-    });
+const rows = await db.select({ id: users.id, name: users.name }).from(users).limit(1);
+const parsed: { id: number; name: string; age: number } = Value.Parse(userSelectSchema, rows[0]); // Error: `age` is not returned in the above query
 
-    // Usage
+const rows = await db.select().from(users).limit(1);
+const parsed: { id: number; name: string; age: number } = Value.Parse(userSelectSchema, rows[0]); // Will parse successfully
+```
 
-    const isUserValid: boolean = Value.Check(insertUserSchema, {
-        name: 'John Doe',
-        email: 'johndoe@test.com',
-        role: 'admin',
-    });
-    ```
+Views and enums are also supported.
+
+```ts copy
+import { pgEnum } from 'drizzle-orm/pg-core';
+import { createSelectSchema } from 'drizzle-typebox';
+import { Value } from '@sinclair/typebox/value';
+
+const roles = pgEnum('roles', ['admin', 'basic']);
+const rolesSchema = createSelectSchema(roles);
+const parsed: 'admin' | 'basic' = Value.Parse(rolesSchema, ...);
+
+const usersView = pgView('users_view').as((qb) => qb.select().from(users).where(gt(users.age, 18)));
+const usersViewSchema = createSelectSchema(usersView);
+const parsed: { id: number; name: string; age: number } = Value.Parse(usersViewSchema, ...);
+```
+
+### Insert schema
+
+Defines the shape of data to be inserted into the database - can be used to validate API requests.
+
+```ts copy
+import { pgTable, text, integer } from 'drizzle-orm/pg-core';
+import { createInsertSchema } from 'drizzle-typebox';
+import { Value } from '@sinclair/typebox/value';
+
+const users = pgTable('users', {
+  id: integer().generatedAlwaysAsIdentity().primaryKey(),
+  name: text().notNull(),
+  age: integer().notNull()
+});
+
+const userInsertSchema = createInsertSchema(users);
+
+const user = { name: 'John' };
+const parsed: { name: string, age: number } = Value.Parse(userInsertSchema, user); // Error: `age` is not defined
+
+const user = { name: 'Jane', age: 30 };
+const parsed: { name: string, age: number } = Value.Parse(userInsertSchema, user); // Will parse successfully
+await db.insert(users).values(parsed);
+```
+
+### Update schema
+
+Defines the shape of data to be updated in the database - can be used to validate API requests.
+
+```ts copy
+import { pgTable, text, integer } from 'drizzle-orm/pg-core';
+import { createUpdateSchema } from 'drizzle-typebox';
+import { Value } from '@sinclair/typebox/value';
+
+const users = pgTable('users', {
+  id: integer().generatedAlwaysAsIdentity().primaryKey(),
+  name: text().notNull(),
+  age: integer().notNull()
+});
+
+const userUpdateSchema = createUpdateSchema(users);
+
+const user = { id: 5, name: 'John' };
+const parsed: { name?: string | undefined, age?: number | undefined } = Value.Parse(userUpdateSchema, user); // Error: `id` is a generated column, it can't be updated
+
+const user = { age: 35 };
+const parsed: { name?: string | undefined, age?: number | undefined } = Value.Parse(userUpdateSchema, user); // Will parse successfully
+await db.update(users).set(parsed).where(eq(users.name, 'Jane'));
+```
+
+### Refinements
+
+Each create schema function accepts an additional optional parameter that you can used to extend, modify or completely overwite a field's schema. Defining a callback function will extend or modify while providing a Typebox schema will overwrite it.
+
+```ts copy
+import { pgTable, text, integer, json } from 'drizzle-orm/pg-core';
+import { createSelectSchema } from 'drizzle-typebox';
+import { Type } from '@sinclair/typebox';
+import { Value } from '@sinclair/typebox/value';
+
+const users = pgTable('users', {
+  id: integer().generatedAlwaysAsIdentity().primaryKey(),
+  name: text().notNull(),
+  bio: text(),
+  preferences: json()
+});
+
+const userSelectSchema = createSelectSchema(users, {
+  name: (schema) => Type.String({ ...schema, maxLength: 20 }), // Extends schema
+  bio: (schema) => Type.String({ ...schema, maxLength: 1000 }), // Extends schema before becoming nullable/optional
+  preferences: Type.Object({ theme: Type.String() }) // Overwrites the field, including its nullability
+});
+
+const parsed: {
+  id: number;
+  name: string,
+  bio?: string | undefined;
+  preferences: {
+    theme: string;
+  };
+} = Value.Parse(userSelectSchema, ...);
+```
+
+### Factory functions
+
+For more advanced use cases, you can use the `createSchemaFactory` function.
+
+**Use case: Using an extended Typebox instance**
+
+```ts copy
+import { pgTable, text, integer } from 'drizzle-orm/pg-core';
+import { createSchemaFactory } from 'drizzle-typebox';
+import { t } from 'elysia'; // Extended Typebox instance
+
+const users = pgTable('users', {
+  id: integer().generatedAlwaysAsIdentity().primaryKey(),
+  name: text().notNull(),
+  age: integer().notNull()
+});
+
+const { createInsertSchema } = createSchemaFactory({ typeboxInstance: t });
+
+const userInsertSchema = createInsertSchema(users, {
+  // We can now use the extended instance
+  name: (schema) => t.Number({ ...schema }, { error: '`name` must be a string' })
+});
+```
+
+### Data type reference
+
+```ts
+pg.boolean();
+
+mysql.boolean();
+
+sqlite.integer({ mode: 'boolean' });
+
+// Schema
+Type.Boolean();
+```
+
+```ts
+pg.date({ mode: 'date' });
+pg.timestamp({ mode: 'date' });
+
+mysql.date({ mode: 'date' });
+mysql.datetime({ mode: 'date' });
+mysql.timestamp({ mode: 'date' });
+
+sqlite.integer({ mode: 'timestamp' });
+sqlite.integer({ mode: 'timestamp_ms' });
+
+// Schema
+Type.Date();
+```
+
+```ts
+pg.date({ mode: 'string' });
+pg.timestamp({ mode: 'string' });
+pg.cidr();
+pg.inet();
+pg.interval();
+pg.macaddr();
+pg.macaddr8();
+pg.numeric();
+pg.text();
+pg.sparsevec();
+pg.time();
+
+mysql.binary();
+mysql.date({ mode: 'string' });
+mysql.datetime({ mode: 'string' });
+mysql.decimal();
+mysql.time();
+mysql.timestamp({ mode: 'string' });
+mysql.varbinary();
+
+sqlite.numeric();
+sqlite.text({ mode: 'text' });
+
+// Schema
+Type.String();
+```
+
+```ts
+pg.bit({ dimensions: ... });
+
+// Schema
+t.RegExp(/^[01]+$/, { maxLength: dimensions });
+```
+
+```ts
+pg.uuid();
+
+// Schema
+Type.String({ format: 'uuid' });
+```
+
+```ts
+pg.char({ length: ... });
+
+mysql.char({ length: ... });
+
+// Schema
+Type.String({ minLength: length, maxLength: length });
+```
+
+```ts
+pg.varchar({ length: ... });
+
+mysql.varchar({ length: ... });
+
+sqlite.text({ mode: 'text', length: ... });
+
+// Schema
+Type.String({ maxLength: length });
+```
+
+```ts
+mysql.tinytext();
+
+// Schema
+Type.String({ maxLength: 255 }); // unsigned 8-bit integer limit
+```
+
+```ts
+mysql.text();
+
+// Schema
+Type.String({ maxLength: 65_535 }); // unsigned 16-bit integer limit
+```
+
+```ts
+mysql.mediumtext();
+
+// Schema
+Type.String({ maxLength: 16_777_215 }); // unsigned 24-bit integer limit
+```
+
+```ts
+mysql.longtext();
+
+// Schema
+Type.String({ maxLength: 4_294_967_295 }); // unsigned 32-bit integer limit
+```
+
+```ts
+pg.text({ enum: ... });
+pg.char({ enum: ... });
+pg.varchar({ enum: ... });
+
+mysql.tinytext({ enum: ... });
+mysql.mediumtext({ enum: ... });
+mysql.text({ enum: ... });
+mysql.longtext({ enum: ... });
+mysql.char({ enum: ... });
+mysql.varchar({ enum: ... });
+mysql.mysqlEnum(..., ...);
+
+sqlite.text({ mode: 'text', enum: ... });
+
+// Schema
+Type.Enum(enum);
+```
+
+```ts
+mysql.tinyint();
+
+// Schema
+Type.Integer({ minimum: -128, maximum: 127 }); // 8-bit integer lower and upper limit
+```
+
+```ts
+mysql.tinyint({ unsigned: true });
+
+// Schema
+Type.Integer({ minimum: 0, maximum: 255 }); // unsigned 8-bit integer lower and upper limit
+```
+
+```ts
+pg.smallint();
+pg.smallserial();
+
+mysql.smallint();
+
+// Schema
+Type.Integer({ minimum: -32_768, maximum: 32_767 }); // 16-bit integer lower and upper limit
+```
+
+```ts
+mysql.smallint({ unsigned: true });
+
+// Schema
+Type.Integer({ minimum: 0, maximum: 65_535 }); // unsigned 16-bit integer lower and upper limit
+```
+
+```ts
+pg.real();
+
+mysql.float();
+
+// Schema
+Type.Number().min(-8_388_608).max(8_388_607); // 24-bit integer lower and upper limit
+```
+
+```ts
+mysql.mediumint();
+
+// Schema
+Type.Integer({ minimum: -8_388_608, maximum: 8_388_607 }); // 24-bit integer lower and upper limit
+```
+
+```ts
+mysql.float({ unsigned: true });
+
+// Schema
+Type.Number({ minimum: 0, maximum: 16_777_215 }); // unsigned 24-bit integer lower and upper limit
+```
+
+```ts
+mysql.mediumint({ unsigned: true });
+
+// Schema
+Type.Integer({ minimum: 0, maximum: 16_777_215 }); // unsigned 24-bit integer lower and upper limit
+```
+
+```ts
+pg.integer();
+pg.serial();
+
+mysql.int();
+
+// Schema
+Type.Integer({ minimum: -2_147_483_648, maximum: 2_147_483_647 }); // 32-bit integer lower and upper limit
+```
+
+```ts
+mysql.int({ unsigned: true });
+
+// Schema
+Type.Integer({ minimum: 0, maximum: 4_294_967_295 }); // unsgined 32-bit integer lower and upper limit
+```
+
+```ts
+pg.doublePrecision();
+
+mysql.double();
+mysql.real();
+
+sqlite.real();
+
+// Schema
+Type.Number({ minimum: -140_737_488_355_328, maximum: 140_737_488_355_327 }); // 48-bit integer lower and upper limit
+```
+
+```ts
+mysql.double({ unsigned: true });
+
+// Schema
+Type.Numer({ minimum: 0, maximum: 281_474_976_710_655 }); // unsigned 48-bit integer lower and upper limit
+```
+
+```ts
+pg.bigint({ mode: 'number' });
+pg.bigserial({ mode: 'number' });
+
+mysql.bigint({ mode: 'number' });
+mysql.bigserial({ mode: 'number' });
+
+sqlite.integer({ mode: 'number' });
+
+// Schema
+Type.Integer({ minimum: -9_007_199_254_740_991, maximum: 9_007_199_254_740_991 }); // Javascript min. and max. safe integers
+```
+
+```ts
+mysql.serial();
+
+Type.Integer({ minimum: 0, maximum: 9_007_199_254_740_991 }); // Javascript max. safe integer
+```
+
+```ts
+pg.bigint({ mode: 'bigint' });
+pg.bigserial({ mode: 'bigint' });
+
+mysql.bigint({ mode: 'bigint' });
+
+sqlite.blob({ mode: 'bigint' });
+
+// Schema
+Type.BigInt({ minimum: -9_223_372_036_854_775_808n, maximum: 9_223_372_036_854_775_807n }); // 64-bit integer lower and upper limit
+```
+
+```ts
+mysql.bigint({ mode: 'bigint', unsigned: true });
+
+// Schema
+Type.BigInt({ minimum: 0, maximum: 18_446_744_073_709_551_615n }); // unsigned 64-bit integer lower and upper limit
+```
+
+```ts
+mysql.year();
+
+// Schema
+Type.Integer({ minimum: 1_901, maximum: 2_155 });
+```
+
+```ts
+pg.geometry({ type: 'point', mode: 'tuple' });
+pg.point({ mode: 'tuple' });
+
+// Schema
+Type.Tuple([Type.Number(), Type.Number()]);
+```
+
+```ts
+pg.geometry({ type: 'point', mode: 'xy' });
+pg.point({ mode: 'xy' });
+
+// Schema
+Type.Object({ x: Type.Number(), y: Type.Number() });
+```
+
+```ts
+pg.halfvec({ dimensions: ... });
+pg.vector({ dimensions: ... });
+
+// Schema
+Type.Array(Type.Number(), { minItems: dimensions, maxItems: dimensions });
+```
+
+```ts
+pg.line({ mode: 'abc' });
+
+// Schema
+Type.Object({ a: Type.Number(), b: Type.Number(), c: Type.Number() });
+```
+
+```ts
+pg.line({ mode: 'tuple' });
+
+// Schema
+Type.Tuple([Type.Number(), Type.Number(), Type.Number()]);
+```
+
+```ts
+pg.json();
+pg.jsonb();
+
+mysql.json();
+
+sqlite.blob({ mode: 'json' });
+sqlite.text({ mode: 'json' });
+
+// Schema
+Type.Recursive((self) => Type.Union([Type.Union([Type.String(), Type.Number(), Type.Boolean(), Type.Null()]), Type.Array(self), Type.Record(Type.String(), self)]));
+```
+
+```ts
+sqlite.blob({ mode: 'buffer' });
+
+// Schema
+TypeRegistry.Set('Buffer', (_, value) => value instanceof Buffer); // drizzle-typebox runs this method to add it to Typebox's type system
+{ [Kind]: 'Buffer', type: 'buffer' }; // The Typebox schema
+```
+
+```ts
+pg.dataType().array(...);
+
+// Schema
+Type.Array(baseDataTypeSchema, { minItems: size, maxItems: size });
+```

--- a/src/content/docs/typebox.mdx
+++ b/src/content/docs/typebox.mdx
@@ -12,6 +12,8 @@ drizzle-typebox
 </Npm>
 
 <Callout type="warning">
+This documentation is for `drizzle-typebox@0.2.0` and higher
+
 You must also have Drizzle ORM v0.36.0 or greater and Typebox v0.34.8 or greater installed.
 </Callout>
 

--- a/src/content/docs/valibot.mdx
+++ b/src/content/docs/valibot.mdx
@@ -12,6 +12,8 @@ drizzle-valibot
 </Npm>
 
 <Callout type="warning">
+This documentation is for `drizzle-valibot@0.3.0` and higher
+
 You must also have Drizzle ORM v0.36.0 or greater and Valibot v1.0.0-beta.7 or greater installed.
 </Callout>
 

--- a/src/content/docs/valibot.mdx
+++ b/src/content/docs/valibot.mdx
@@ -1,8 +1,9 @@
 import Npm from '@mdx/Npm.astro';
+import Callout from '@mdx/Callout.astro';
 
 # drizzle-valibot
 
-`drizzle-valibot` is a plugin for **[Drizzle ORM](https://github.com/drizzle-team/drizzle-orm)** that allows you to generate **[valibot](https://valibot.dev/)** schemas from Drizzle ORM schemas.
+`drizzle-valibot` is a plugin for **[Drizzle ORM](https://github.com/drizzle-team/drizzle-orm)** that allows you to generate **[Valibot](https://valibot.dev/)** schemas from Drizzle ORM schemas.
 
 ### Install the dependencies
 
@@ -10,43 +11,473 @@ import Npm from '@mdx/Npm.astro';
 drizzle-valibot
 </Npm>
 
-# Usage
+<Callout type="warning">
+You must also have Drizzle ORM v0.36.0 or greater and Valibot v1.0.0-beta.7 or greater installed.
+</Callout>
 
-```ts
-import { pgEnum, pgTable, serial, text, timestamp } from 'drizzle-orm/pg-core';
-import { createInsertSchema, createSelectSchema } from 'drizzle-valibot';
-import { string, parse, number } from 'valibot';
+### Select schema
+
+Defines the shape of data queried from the database - can be used to validate API responses.
+
+```ts copy
+import { pgTable, text, integer } from 'drizzle-orm/pg-core';
+import { createSelectSchema } from 'drizzle-valibot';
+import { parse } from 'valibot';
 
 const users = pgTable('users', {
-	id: serial('id').primaryKey(),
-	name: text('name').notNull(),
-	email: text('email').notNull(),
-	role: text('role', { enum: ['admin', 'user'] }).notNull(),
-	createdAt: timestamp('created_at').notNull().defaultNow(),
+  id: integer().generatedAlwaysAsIdentity().primaryKey(),
+  name: text().notNull(),
+  age: integer().notNull()
 });
 
-// Schema for inserting a user - can be used to validate API requests
-const insertUserSchema = createInsertSchema(users);
+const userSelectSchema = createSelectSchema(users);
 
-// Schema for selecting a user - can be used to validate API responses
-const selectUserSchema = createSelectSchema(users);
+const rows = await db.select({ id: users.id, name: users.name }).from(users).limit(1);
+const parsed: { id: number; name: string; age: number } = parse(userSelectSchema, rows[0]); // Error: `age` is not returned in the above query
 
-// Overriding the fields
-const insertUserSchema = createInsertSchema(users, {
-	role: string(),
+const rows = await db.select().from(users).limit(1);
+const parsed: { id: number; name: string; age: number } = parse(userSelectSchema, rows[0]); // Will parse successfully
+```
+
+Views and enums are also supported.
+
+```ts copy
+import { pgEnum } from 'drizzle-orm/pg-core';
+import { createSelectSchema } from 'drizzle-valibot';
+import { parse } from 'valibot';
+
+const roles = pgEnum('roles', ['admin', 'basic']);
+const rolesSchema = createSelectSchema(roles);
+const parsed: 'admin' | 'basic' = parse(rolesSchema, ...);
+
+const usersView = pgView('users_view').as((qb) => qb.select().from(users).where(gt(users.age, 18)));
+const usersViewSchema = createSelectSchema(usersView);
+const parsed: { id: number; name: string; age: number } = parse(usersViewSchema, ...);
+```
+
+### Insert schema
+
+Defines the shape of data to be inserted into the database - can be used to validate API requests.
+
+```ts copy
+import { pgTable, text, integer } from 'drizzle-orm/pg-core';
+import { createInsertSchema } from 'drizzle-valibot';
+import { parse } from 'valibot';
+
+const users = pgTable('users', {
+  id: integer().generatedAlwaysAsIdentity().primaryKey(),
+  name: text().notNull(),
+  age: integer().notNull()
 });
 
-// Refining the fields - useful if you want to change the fields before they become nullable/optional in the final schema
-const insertUserSchema = createInsertSchema(users, {
-	id: (schema) => number([minValue(0)]),
-	role: string(),
+const userInsertSchema = createInsertSchema(users);
+
+const user = { name: 'John' };
+const parsed: { name: string, age: number } = parse(userInsertSchema, user); // Error: `age` is not defined
+
+const user = { name: 'Jane', age: 30 };
+const parsed: { name: string, age: number } = parse(userInsertSchema, user); // Will parse successfully
+await db.insert(users).values(parsed);
+```
+
+### Update schema
+
+Defines the shape of data to be updated in the database - can be used to validate API requests.
+
+```ts copy
+import { pgTable, text, integer } from 'drizzle-orm/pg-core';
+import { createUpdateSchema } from 'drizzle-valibot';
+import { parse } from 'valibot';
+
+const users = pgTable('users', {
+  id: integer().generatedAlwaysAsIdentity().primaryKey(),
+  name: text().notNull(),
+  age: integer().notNull()
 });
 
-// Usage
+const userUpdateSchema = createUpdateSchema(users);
 
-const isUserValid = parse(insertUserSchema, {
-	name: 'John Doe',
-	email: 'johndoe@test.com',
-	role: 'admin',
+const user = { id: 5, name: 'John' };
+const parsed: { name?: string | undefined, age?: number | undefined } = parse(userUpdateSchema, user); // Error: `id` is a generated column, it can't be updated
+
+const user = { age: 35 };
+const parsed: { name?: string | undefined, age?: number | undefined } = parse(userUpdateSchema, user); // Will parse successfully
+await db.update(users).set(parsed).where(eq(users.name, 'Jane'));
+```
+
+### Refinements
+
+Each create schema function accepts an additional optional parameter that you can used to extend, modify or completely overwite a field's schema. Defining a callback function will extend or modify while providing a Valibot schema will overwrite it.
+
+```ts copy
+import { pgTable, text, integer, json } from 'drizzle-orm/pg-core';
+import { createSelectSchema } from 'drizzle-valibot';
+import { parse, pipe, maxLength, object, string } from 'valibot';
+
+const users = pgTable('users', {
+  id: integer().generatedAlwaysAsIdentity().primaryKey(),
+  name: text().notNull(),
+  bio: text(),
+  preferences: json()
 });
+
+const userSelectSchema = createSelectSchema(users, {
+  name: (schema) => pipe(schema, maxLength(20)), // Extends schema
+  bio: (schema) => pipe(schema, maxLength(1000)), // Extends schema before becoming nullable/optional
+  preferences: object({ theme: string() }) // Overwrites the field, including its nullability
+});
+
+const parsed: {
+  id: number;
+  name: string,
+  bio?: string | undefined;
+  preferences: {
+    theme: string;
+  };
+} = parse(userSelectSchema, ...);
+```
+
+### Data type reference
+
+```ts
+pg.boolean();
+
+mysql.boolean();
+
+sqlite.integer({ mode: 'boolean' });
+
+// Schema
+boolean();
+```
+
+```ts
+pg.date({ mode: 'date' });
+pg.timestamp({ mode: 'date' });
+
+mysql.date({ mode: 'date' });
+mysql.datetime({ mode: 'date' });
+mysql.timestamp({ mode: 'date' });
+
+sqlite.integer({ mode: 'timestamp' });
+sqlite.integer({ mode: 'timestamp_ms' });
+
+// Schema
+date();
+```
+
+```ts
+pg.date({ mode: 'string' });
+pg.timestamp({ mode: 'string' });
+pg.cidr();
+pg.inet();
+pg.interval();
+pg.macaddr();
+pg.macaddr8();
+pg.numeric();
+pg.text();
+pg.sparsevec();
+pg.time();
+
+mysql.binary();
+mysql.date({ mode: 'string' });
+mysql.datetime({ mode: 'string' });
+mysql.decimal();
+mysql.time();
+mysql.timestamp({ mode: 'string' });
+mysql.varbinary();
+
+sqlite.numeric();
+sqlite.text({ mode: 'text' });
+
+// Schema
+string();
+```
+
+```ts
+pg.bit({ dimensions: ... });
+
+// Schema
+pipe(string(), regex(/^[01]+$/), maxLength(dimensions));
+```
+
+```ts
+pg.uuid();
+
+// Schema
+pipe(string(), uuid());
+```
+
+```ts
+pg.char({ length: ... });
+
+mysql.char({ length: ... });
+
+// Schema
+pipe(string(), length(length));
+```
+
+```ts
+pg.varchar({ length: ... });
+
+mysql.varchar({ length: ... });
+
+sqlite.text({ mode: 'text', length: ... });
+
+// Schema
+pipe(string(), maxLength(length));
+```
+
+```ts
+mysql.tinytext();
+
+// Schema
+pipe(string(), maxLength(255)); // unsigned 8-bit integer limit
+```
+
+```ts
+mysql.text();
+
+// Schema
+pipe(string(), maxLength(65_535)); // unsigned 16-bit integer limit
+```
+
+```ts
+mysql.mediumtext();
+
+// Schema
+pipe(string(), maxLength(16_777_215)); // unsigned 24-bit integer limit
+```
+
+```ts
+mysql.longtext();
+
+// Schema
+pipe(string(), maxLength(4_294_967_295)); // unsigned 32-bit integer limit
+```
+
+```ts
+pg.text({ enum: ... });
+pg.char({ enum: ... });
+pg.varchar({ enum: ... });
+
+mysql.tinytext({ enum: ... });
+mysql.mediumtext({ enum: ... });
+mysql.text({ enum: ... });
+mysql.longtext({ enum: ... });
+mysql.char({ enum: ... });
+mysql.varchar({ enum: ... });
+mysql.mysqlEnum(..., ...);
+
+sqlite.text({ mode: 'text', enum: ... });
+
+// Schema
+enum(enum);
+```
+
+```ts
+mysql.tinyint();
+
+// Schema
+pipe(number(), minValue(-128), maxValue(127), integer()); // 8-bit integer lower and upper limit
+```
+
+```ts
+mysql.tinyint({ unsigned: true });
+
+// Schema
+pipe(number(), minValue(0), maxValue(255), integer()); // unsigned 8-bit integer lower and upper limit
+```
+
+```ts
+pg.smallint();
+pg.smallserial();
+
+mysql.smallint();
+
+// Schema
+pipe(number(), minValue(-32_768), maxValue(32_767), integer()); // 16-bit integer lower and upper limit
+```
+
+```ts
+mysql.smallint({ unsigned: true });
+
+// Schema
+pipe(number(), minValue(0), maxValue(65_535), integer()); // unsigned 16-bit integer lower and upper limit
+```
+
+```ts
+pg.real();
+
+mysql.float();
+
+// Schema
+pipe(number(), minValue(-8_388_608), maxValue(8_388_607)); // 24-bit integer lower and upper limit
+```
+
+```ts
+mysql.mediumint();
+
+// Schema
+pipe(number(), minValue(-8_388_608), maxValue(8_388_607), integer()); // 24-bit integer lower and upper limit
+```
+
+```ts
+mysql.float({ unsigned: true });
+
+// Schema
+pipe(number(), minValue(0), maxValue(16_777_215)); // unsigned 24-bit integer lower and upper limit
+```
+
+```ts
+mysql.mediumint({ unsigned: true });
+
+// Schema
+pipe(number(), minValue(0), maxValue(16_777_215), integer()); // unsigned 24-bit integer lower and upper limit
+```
+
+```ts
+pg.integer();
+pg.serial();
+
+mysql.int();
+
+// Schema
+pipe(number(), minValue(-2_147_483_648), maxValue(2_147_483_647), integer()); // 32-bit integer lower and upper limit
+```
+
+```ts
+mysql.int({ unsigned: true });
+
+// Schema
+pipe(number(), minValue(0), maxValue(4_294_967_295), integer()); // unsgined 32-bit integer lower and upper limit
+```
+
+```ts
+pg.doublePrecision();
+
+mysql.double();
+mysql.real();
+
+sqlite.real();
+
+// Schema
+pipe(number(), minValue(-140_737_488_355_328), maxValue(140_737_488_355_327)); // 48-bit integer lower and upper limit
+```
+
+```ts
+mysql.double({ unsigned: true });
+
+// Schema
+pipe(number(), minValue(0), maxValue(281_474_976_710_655)); // unsigned 48-bit integer lower and upper limit
+```
+
+```ts
+pg.bigint({ mode: 'number' });
+pg.bigserial({ mode: 'number' });
+
+mysql.bigint({ mode: 'number' });
+mysql.bigserial({ mode: 'number' });
+
+sqlite.integer({ mode: 'number' });
+
+// Schema
+pipe(number(), minValue(-9_007_199_254_740_991), maxValue(9_007_199_254_740_991), integer()); // Javascript min. and max. safe integers
+```
+
+```ts
+mysql.serial();
+
+// Schema
+pipe(number(), minValue(0), maxValue(9_007_199_254_740_991), integer()); // Javascript max. safe integer
+```
+
+```ts
+pg.bigint({ mode: 'bigint' });
+pg.bigserial({ mode: 'bigint' });
+
+mysql.bigint({ mode: 'bigint' });
+
+sqlite.blob({ mode: 'bigint' });
+
+// Schema
+pipe(bigint(), minValue(-9_223_372_036_854_775_808n), maxValue(9_223_372_036_854_775_807n)); // 64-bit integer lower and upper limit
+```
+
+```ts
+mysql.bigint({ mode: 'bigint', unsigned: true });
+
+// Schema
+pipe(bigint(), minValue(0), maxValue(18_446_744_073_709_551_615n)); // unsigned 64-bit integer lower and upper limit
+```
+
+```ts
+mysql.year();
+
+// Schema
+pipe(number(), minValue(1_901), maxValue(2_155), integer());
+```
+
+```ts
+pg.geometry({ type: 'point', mode: 'tuple' });
+pg.point({ mode: 'tuple' });
+
+// Schema
+tuple([number(), number()]);
+```
+
+```ts
+pg.geometry({ type: 'point', mode: 'xy' });
+pg.point({ mode: 'xy' });
+
+// Schema
+object({ x: number(), y: number() });
+```
+
+```ts
+pg.halfvec({ dimensions: ... });
+pg.vector({ dimensions: ... });
+
+// Schema
+pipe(array(number()), length(dimensions));
+```
+
+```ts
+pg.line({ mode: 'abc' });
+
+// Schema
+object({ a: number(), b: number(), c: number() });
+```
+
+```ts
+pg.line({ mode: 'tuple' });
+
+// Schema
+tuple([number(), number(), number()]);
+```
+
+```ts
+pg.json();
+pg.jsonb();
+
+mysql.json();
+
+sqlite.blob({ mode: 'json' });
+sqlite.text({ mode: 'json' });
+
+// Schema
+const self = union([union([string(), number(), boolean(), null()]), array(lazy(() => self)), record(string(), lazy(() => self))]);
+```
+
+```ts
+sqlite.blob({ mode: 'buffer' });
+
+// Schema
+custom<Buffer>((v) => v instanceof Buffer);
+```
+
+```ts
+pg.dataType().array(...);
+
+// Schema
+pipe(array(baseDataTypeSchema), length(size));
 ```

--- a/src/content/docs/zod.mdx
+++ b/src/content/docs/zod.mdx
@@ -1,4 +1,5 @@
 import Npm from '@mdx/Npm.astro';
+import Callout from '@mdx/Callout.astro';
 
 # drizzle-zod
 
@@ -10,47 +11,494 @@ import Npm from '@mdx/Npm.astro';
 drizzle-zod
 </Npm>
 
-# Usage
+<Callout type="warning">
+You must also have Drizzle ORM v0.36.0 or greater and Zod v3.0.0 or greater installed.
+</Callout>
+
+### Select schema
+
+Defines the shape of data queried from the database - can be used to validate API responses.
 
 ```ts copy
-import { pgEnum, pgTable, serial, text, timestamp } from 'drizzle-orm/pg-core';
-import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
+import { pgTable, text, integer } from 'drizzle-orm/pg-core';
+import { createSelectSchema } from 'drizzle-zod';
+
+const users = pgTable('users', {
+  id: integer().generatedAlwaysAsIdentity().primaryKey(),
+  name: text().notNull(),
+  age: integer().notNull()
+});
+
+const userSelectSchema = createSelectSchema(users);
+
+const rows = await db.select({ id: users.id, name: users.name }).from(users).limit(1);
+const parsed: { id: number; name: string; age: number } = userSelectSchema.parse(rows[0]); // Error: `age` is not returned in the above query
+
+const rows = await db.select().from(users).limit(1);
+const parsed: { id: number; name: string; age: number } = userSelectSchema.parse(rows[0]); // Will parse successfully
+```
+
+Views and enums are also supported.
+
+```ts copy
+import { pgEnum } from 'drizzle-orm/pg-core';
+import { createSelectSchema } from 'drizzle-zod';
+
+const roles = pgEnum('roles', ['admin', 'basic']);
+const rolesSchema = createSelectSchema(roles);
+const parsed: 'admin' | 'basic' = rolesSchema.parse(...);
+
+const usersView = pgView('users_view').as((qb) => qb.select().from(users).where(gt(users.age, 18)));
+const usersViewSchema = createSelectSchema(usersView);
+const parsed: { id: number; name: string; age: number } = usersViewSchema.parse(...);
+```
+
+### Insert schema
+
+Defines the shape of data to be inserted into the database - can be used to validate API requests.
+
+```ts copy
+import { pgTable, text, integer } from 'drizzle-orm/pg-core';
+import { createInsertSchema } from 'drizzle-zod';
+
+const users = pgTable('users', {
+  id: integer().generatedAlwaysAsIdentity().primaryKey(),
+  name: text().notNull(),
+  age: integer().notNull()
+});
+
+const userInsertSchema = createInsertSchema(users);
+
+const user = { name: 'John' };
+const parsed: { name: string, age: number } = userInsertSchema.parse(user); // Error: `age` is not defined
+
+const user = { name: 'Jane', age: 30 };
+const parsed: { name: string, age: number } = userInsertSchema.parse(user); // Will parse successfully
+await db.insert(users).values(parsed);
+```
+
+### Update schema
+
+Defines the shape of data to be updated in the database - can be used to validate API requests.
+
+```ts copy
+import { pgTable, text, integer } from 'drizzle-orm/pg-core';
+import { createUpdateSchema } from 'drizzle-zod';
+
+const users = pgTable('users', {
+  id: integer().generatedAlwaysAsIdentity().primaryKey(),
+  name: text().notNull(),
+  age: integer().notNull()
+});
+
+const userUpdateSchema = createUpdateSchema(users);
+
+const user = { id: 5, name: 'John' };
+const parsed: { name?: string | undefined, age?: number | undefined } = userUpdateSchema.parse(user); // Error: `id` is a generated column, it can't be updated
+
+const user = { age: 35 };
+const parsed: { name?: string | undefined, age?: number | undefined } = userUpdateSchema.parse(user); // Will parse successfully
+await db.update(users).set(parsed).where(eq(users.name, 'Jane'));
+```
+
+### Refinements
+
+Each create schema function accepts an additional optional parameter that you can used to extend, modify or completely overwite a field's schema. Defining a callback function will extend or modify while providing a Zod schema will overwrite it.
+
+```ts copy
+import { pgTable, text, integer, json } from 'drizzle-orm/pg-core';
+import { createSelectSchema } from 'drizzle-zod';
 import { z } from 'zod';
 
 const users = pgTable('users', {
-  id: serial('id').primaryKey(),
-  name: text('name').notNull(),
-  email: text('email').notNull(),
-  role: text('role', { enum: ['admin', 'user'] }).notNull(),
-  createdAt: timestamp('created_at').notNull().defaultNow(),
+  id: integer().generatedAlwaysAsIdentity().primaryKey(),
+  name: text().notNull(),
+  bio: text(),
+  preferences: json()
 });
 
-// Schema for inserting a user - can be used to validate API requests
-const insertUserSchema = createInsertSchema(users);
-
-// Schema for selecting a user - can be used to validate API responses
-const selectUserSchema = createSelectSchema(users);
-
-// Overriding the fields
-const insertUserSchema = createInsertSchema(users, {
-  role: z.string(),
+const userSelectSchema = createSelectSchema(users, {
+  name: (schema) => schema.max(20), // Extends schema
+  bio: (schema) => schema.max(1000), // Extends schema before becoming nullable/optional
+  preferences: z.object({ theme: z.string() }) // Overwrites the field, including its nullability
 });
 
-// Refining the fields - useful if you want to change the fields before they become nullable/optional in the final schema
-const insertUserSchema = createInsertSchema(users, {
-  id: (schema) => schema.id.positive(),
-  email: (schema) => schema.email.email(),
-  role: z.string(),
+const parsed: {
+  id: number;
+  name: string,
+  bio?: string | undefined;
+  preferences: {
+    theme: string;
+  };
+} = userSelectSchema.parse(...);
+```
+
+### Factory functions
+
+For more advanced use cases, you can use the `createSchemaFactory` function.
+
+**Use case: Using an extended Zod instance**
+
+```ts copy
+import { pgTable, text, integer } from 'drizzle-orm/pg-core';
+import { createSchemaFactory } from 'drizzle-zod';
+import { z } from '@hono/zod-openapi'; // Extended Zod instance
+
+const users = pgTable('users', {
+  id: integer().generatedAlwaysAsIdentity().primaryKey(),
+  name: text().notNull(),
+  age: integer().notNull()
 });
 
-// Usage
+const { createInsertSchema } = createSchemaFactory({ zodInstance: z });
 
-const user = insertUserSchema.parse({
-  name: 'John Doe',
-  email: 'johndoe@test.com',
-  role: 'admin',
+const userInsertSchema = createInsertSchema(users, {
+  // We can now use the extended instance
+  name: (schema) => schema.openapi({ example: 'John' })
 });
+```
 
-// Zod schema type is also inferred from the table schema, so you have full type safety
-const requestSchema = insertUserSchema.pick({ name: true, email: true });
+### Data type reference
+
+```ts
+pg.boolean();
+
+mysql.boolean();
+
+sqlite.integer({ mode: 'boolean' });
+
+// Schema
+z.boolean();
+```
+
+```ts
+pg.date({ mode: 'date' });
+pg.timestamp({ mode: 'date' });
+
+mysql.date({ mode: 'date' });
+mysql.datetime({ mode: 'date' });
+mysql.timestamp({ mode: 'date' });
+
+sqlite.integer({ mode: 'timestamp' });
+sqlite.integer({ mode: 'timestamp_ms' });
+
+// Schema
+z.date();
+```
+
+```ts
+pg.date({ mode: 'string' });
+pg.timestamp({ mode: 'string' });
+pg.cidr();
+pg.inet();
+pg.interval();
+pg.macaddr();
+pg.macaddr8();
+pg.numeric();
+pg.text();
+pg.sparsevec();
+pg.time();
+
+mysql.binary();
+mysql.date({ mode: 'string' });
+mysql.datetime({ mode: 'string' });
+mysql.decimal();
+mysql.time();
+mysql.timestamp({ mode: 'string' });
+mysql.varbinary();
+
+sqlite.numeric();
+sqlite.text({ mode: 'text' });
+
+// Schema
+z.string();
+```
+
+```ts
+pg.bit({ dimensions: ... });
+
+// Schema
+z.string().regex(/^[01]+$/).max(dimensions);
+```
+
+```ts
+pg.uuid();
+
+// Schema
+z.string().uuid();
+```
+
+```ts
+pg.char({ length: ... });
+
+mysql.char({ length: ... });
+
+// Schema
+z.string().length(length);
+```
+
+```ts
+pg.varchar({ length: ... });
+
+mysql.varchar({ length: ... });
+
+sqlite.text({ mode: 'text', length: ... });
+
+// Schema
+z.string().max(length);
+```
+
+```ts
+mysql.tinytext();
+
+// Schema
+z.string().max(255); // unsigned 8-bit integer limit
+```
+
+```ts
+mysql.text();
+
+// Schema
+z.string().max(65_535); // unsigned 16-bit integer limit
+```
+
+```ts
+mysql.mediumtext();
+
+// Schema
+z.string().max(16_777_215); // unsigned 24-bit integer limit
+```
+
+```ts
+mysql.longtext();
+
+// Schema
+z.string().max(4_294_967_295); // unsigned 32-bit integer limit
+```
+
+```ts
+pg.text({ enum: ... });
+pg.char({ enum: ... });
+pg.varchar({ enum: ... });
+
+mysql.tinytext({ enum: ... });
+mysql.mediumtext({ enum: ... });
+mysql.text({ enum: ... });
+mysql.longtext({ enum: ... });
+mysql.char({ enum: ... });
+mysql.varchar({ enum: ... });
+mysql.mysqlEnum(..., ...);
+
+sqlite.text({ mode: 'text', enum: ... });
+
+// Schema
+z.enum(enum);
+```
+
+```ts
+mysql.tinyint();
+
+// Schema
+z.number().min(-128).max(127).int(); // 8-bit integer lower and upper limit
+```
+
+```ts
+mysql.tinyint({ unsigned: true });
+
+// Schema
+z.number().min(0).max(255).int(); // unsigned 8-bit integer lower and upper limit
+```
+
+```ts
+pg.smallint();
+pg.smallserial();
+
+mysql.smallint();
+
+// Schema
+z.number().min(-32_768).max(32_767).int(); // 16-bit integer lower and upper limit
+```
+
+```ts
+mysql.smallint({ unsigned: true });
+
+// Schema
+z.number().min(0).max(65_535).int(); // unsigned 16-bit integer lower and upper limit
+```
+
+```ts
+pg.real();
+
+mysql.float();
+
+// Schema
+z.number().min(-8_388_608).max(8_388_607); // 24-bit integer lower and upper limit
+```
+
+```ts
+mysql.mediumint();
+
+// Schema
+z.number().min(-8_388_608).max(8_388_607).int(); // 24-bit integer lower and upper limit
+```
+
+```ts
+mysql.float({ unsigned: true });
+
+// Schema
+z.number().min(0).max(16_777_215); // unsigned 24-bit integer lower and upper limit
+```
+
+```ts
+mysql.mediumint({ unsigned: true });
+
+// Schema
+z.number().min(0).max(16_777_215).int(); // unsigned 24-bit integer lower and upper limit
+```
+
+```ts
+pg.integer();
+pg.serial();
+
+mysql.int();
+
+// Schema
+z.number().min(-2_147_483_648).max(2_147_483_647).int(); // 32-bit integer lower and upper limit
+```
+
+```ts
+mysql.int({ unsigned: true });
+
+// Schema
+z.number().min(0).max(4_294_967_295).int(); // unsgined 32-bit integer lower and upper limit
+```
+
+```ts
+pg.doublePrecision();
+
+mysql.double();
+mysql.real();
+
+sqlite.real();
+
+// Schema
+z.number().min(-140_737_488_355_328).max(140_737_488_355_327); // 48-bit integer lower and upper limit
+```
+
+```ts
+mysql.double({ unsigned: true });
+
+// Schema
+z.number().min(0).max(281_474_976_710_655); // unsigned 48-bit integer lower and upper limit
+```
+
+```ts
+pg.bigint({ mode: 'number' });
+pg.bigserial({ mode: 'number' });
+
+mysql.bigint({ mode: 'number' });
+mysql.bigserial({ mode: 'number' });
+
+sqlite.integer({ mode: 'number' });
+
+// Schema
+z.number().min(-9_007_199_254_740_991).max(9_007_199_254_740_991).int(); // Javascript min. and max. safe integers
+```
+
+```ts
+mysql.serial();
+
+// Schema
+z.number().min(0).max(9_007_199_254_740_991).int(); // Javascript max. safe integer
+```
+
+```ts
+pg.bigint({ mode: 'bigint' });
+pg.bigserial({ mode: 'bigint' });
+
+mysql.bigint({ mode: 'bigint' });
+
+sqlite.blob({ mode: 'bigint' });
+
+// Schema
+z.bigint().min(-9_223_372_036_854_775_808n).max(9_223_372_036_854_775_807n); // 64-bit integer lower and upper limit
+```
+
+```ts
+mysql.bigint({ mode: 'bigint', unsigned: true });
+
+// Schema
+z.bigint().min(0).max(18_446_744_073_709_551_615n); // unsigned 64-bit integer lower and upper limit
+```
+
+```ts
+mysql.year();
+
+// Schema
+z.number().min(1_901).max(2_155).int();
+```
+
+```ts
+pg.geometry({ type: 'point', mode: 'tuple' });
+pg.point({ mode: 'tuple' });
+
+// Schema
+z.tuple([z.number(), z.number()]);
+```
+
+```ts
+pg.geometry({ type: 'point', mode: 'xy' });
+pg.point({ mode: 'xy' });
+
+// Schema
+z.object({ x: z.number(), y: z.number() });
+```
+
+```ts
+pg.halfvec({ dimensions: ... });
+pg.vector({ dimensions: ... });
+
+// Schema
+z.array(z.number()).length(dimensions);
+```
+
+```ts
+pg.line({ mode: 'abc' });
+
+// Schema
+z.object({ a: z.number(), b: z.number(), c: z.number() });
+```
+
+```ts
+pg.line({ mode: 'tuple' });
+
+// Schema
+z.tuple([z.number(), z.number(), z.number()]);
+```
+
+```ts
+pg.json();
+pg.jsonb();
+
+mysql.json();
+
+sqlite.blob({ mode: 'json' });
+sqlite.text({ mode: 'json' });
+
+// Schema
+const self = z.lazy(() => z.union([z.union([z.string(), z.number(), z.boolean(), z.null()]), z.array(self), z.record(self)]));
+```
+
+```ts
+sqlite.blob({ mode: 'buffer' });
+
+// Schema
+z.custom<Buffer>((v) => v instanceof Buffer);
+```
+
+```ts
+pg.dataType().array(...);
+
+// Schema
+z.array(baseDataTypeSchema).length(size);
 ```

--- a/src/content/docs/zod.mdx
+++ b/src/content/docs/zod.mdx
@@ -12,6 +12,8 @@ drizzle-zod
 </Npm>
 
 <Callout type="warning">
+This documentation is for `drizzle-zod@0.6.0` and higher
+
 You must also have Drizzle ORM v0.36.0 or greater and Zod v3.0.0 or greater installed.
 </Callout>
 


### PR DESCRIPTION
This PR overhauls the documentaiton for drizzle-zod, drizzle-valibot and drizzle-typebox packages to include more specific details on use, examples and references.