### PR TITLE
docs: use `defineConfig` instead of `Config`

### DIFF
--- a/src/content/docs/connect-expo-sqlite.mdx
+++ b/src/content/docs/connect-expo-sqlite.mdx
@@ -86,14 +86,14 @@ module.exports = config;
 
 Make sure to have `dialect: 'sqlite'` and `driver: 'expo'` in Drizzle Kit config
 ```ts filename="drizzle.config.ts"
-import type { Config } from 'drizzle-kit';
+import { defineConfig } from 'drizzle-kit';
 
-export default {
+export default defineConfig({
 	schema: './db/schema.ts',
 	out: './drizzle',
   dialect: 'sqlite',
 	driver: 'expo', // <--- very important
-} satisfies Config;
+});
 ```
 
 #### Generate migrations

--- a/src/content/docs/connect-op-sqlite.mdx
+++ b/src/content/docs/connect-op-sqlite.mdx
@@ -64,14 +64,14 @@ module.exports = config;
 
 Make sure to have `dialect: 'sqlite'` and `driver: 'expo'` in Drizzle Kit config
 ```ts filename="drizzle.config.ts"
-import type { Config } from 'drizzle-kit';
+import { defineConfig } from 'drizzle-kit';
 
-export default {
+export default defineConfig({
 	schema: './db/schema.ts',
 	out: './drizzle',
   dialect: 'sqlite',
 	driver: 'expo', // <--- very important
-} satisfies Config;
+});
 ```
 
 #### Generate migrations


### PR DESCRIPTION
## Before

```ts
import type { Config } from 'drizzle-kit';

export default {
  // ...
} satisfies Config;
```

## After

```ts
import { defineConfig } from 'drizzle-kit';

export default defineConfig({
  // ...
});
```

## Why?

To match the content of the [drizzle.config.ts docs](https://orm.drizzle.team/docs/drizzle-config-file).