### PR TITLE
docs: update SQLite timestamp_ms example to allow millisecond defaults

### DIFF
--- a/src/content/docs/guides/timestamp-default-value.mdx
+++ b/src/content/docs/guides/timestamp-default-value.mdx
@@ -267,7 +267,7 @@ export const users = sqliteTable('users', {
     .default(sql`(unixepoch())`),
   timestamp2: integer('timestamp2', { mode: 'timestamp_ms' })
     .notNull()
-    .default(sql`(unixepoch() * 1000)`),
+    .default(sql`(CAST(unixepoch('subsec') * 1000 as INT))`),
   timestamp3: integer('timestamp3', { mode: 'number' })
     .notNull()
     .default(sql`(unixepoch())`),
@@ -278,7 +278,7 @@ export const users = sqliteTable('users', {
 CREATE TABLE `users` (
 	`id` integer PRIMARY KEY NOT NULL,
 	`timestamp1` integer DEFAULT (unixepoch()) NOT NULL,
-	`timestamp2` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	`timestamp2` integer DEFAULT (CAST(unixepoch('subsec') * 1000 as INT)) NOT NULL,
 	`timestamp3` integer DEFAULT (unixepoch()) NOT NULL
 );
 ```
@@ -293,7 +293,7 @@ The difference is that `timestamp` handles seconds, while `timestamp_ms` handles
 +------------+------------+---------------+------------+
 | id         | timestamp1 | timestamp2    | timestamp3 |
 +------------+------------+---------------+------------+
-| 1          | 1712835640 | 1712835640000 | 1712835640 |
+| 1          | 1712835640 | 1712835640123 | 1712835640 |
 +------------+------------+---------------+------------+
 ```
 
@@ -303,7 +303,7 @@ The difference is that `timestamp` handles seconds, while `timestamp_ms` handles
   {
     id: 1,
     timestamp1: 2024-04-11T11:40:40.000Z, // Date object
-    timestamp2: 2024-04-11T11:40:40.000Z, // Date object
+    timestamp2: 2024-04-11T11:40:40.123Z, // Date object
     timestamp3: 1712835640 // number
   }
 ]


### PR DESCRIPTION
The current SQLite examples for setting the default value for a `timestamp_ms` column do not include the actual millisecond value of the current time, simply multiplying the UNIX timestamp in seconds by 1000.  We can, however, obtain the millisecond value with the 'subsec' modifier to the `unixepoch` function, which returns a float, which we can cast to an integer value:

`select unixepoch() * 1000, unixepoch('subsec'), CAST(unixepoch('subsec') * 1000 as INT);`

| unixepoch() * 1000 | unixepoch('subsec') | CAST(unixepoch('subsec') * 1000 as INT) |
| :---: | :---: | :---: |
| 1733502310000 | 1733502310.844 | 1733502310844 |

One concern is this note from the [SQLite Date/Time Function Docs](https://www.sqlite.org/lang_datefunc.html#subsec):
> The current implemention [sic] increases the resolution from seconds to milliseconds, but this might increase to a higher resolution in future releases of SQLite

But I don't think that would change the output.