### PR TITLE
fix: update indexes-constraints page pgTable to the correct signature

### DIFF
--- a/src/content/docs/indexes-constraints.mdx
+++ b/src/content/docs/indexes-constraints.mdx
@@ -216,18 +216,18 @@ A `PRIMARY KEY` constraint automatically has a `UNIQUE` constraint.
       export const composite = pgTable('composite_example', {
         id: integer('id'),
         name: text('name'),
-      }, (t) => [{
-        unq: unique().on(t.id, t.name),
-        unq2: unique('custom_name').on(t.id, t.name)
-      }]);
+      }, (t) => [
+        unique().on(t.id, t.name),
+        unique('custom_name').on(t.id, t.name)
+      ]);
 
       // In Postgres 15.0+ NULLS NOT DISTINCT is available
       // This example demonstrates both available usages
       export const userNulls = pgTable('user_nulls_example', {
         id: integer('id').unique("custom_name", { nulls: 'not distinct' }),
-      }, (t) => [{
-        unq: unique().on(t.id).nullsNotDistinct()
-      }]);
+      }, (t) => [
+        unique().on(t.id).nullsNotDistinct()
+      ]);
       ```
 
       ```sql
@@ -411,9 +411,9 @@ If you define a `CHECK` constraint on a table it can limit the values in certain
           username: text().notNull(),
           age: integer(),
         },
-        (table) => [{
-          checkConstraint: check("age_check1", sql`${table.age} > 21`),
-        }]
+        (table) => [
+          check("age_check1", sql`${table.age} > 21`),
+        ]
       );
       ```
       ```sql
@@ -629,10 +629,10 @@ Drizzle ORM provides a standalone `primaryKey` operator for that:
         authorId: integer("author_id"),
         bookId: integer("book_id"),
       }, (table) => {
-        return [{
-          pk: primaryKey({ columns: [table.bookId, table.authorId] }),
-          pkWithCustomName: primaryKey({ name: 'custom_name', columns: [table.bookId, table.authorId] }),
-        }];
+        return [
+          primaryKey({ columns: [table.bookId, table.authorId] }),
+          primaryKey({ name: 'custom_name', columns: [table.bookId, table.authorId] }),
+        ];
       });
       ```
 
@@ -851,13 +851,13 @@ set return type for reference callback or use a standalone `foreignKey` operator
       name: text("name"),
       parentId: integer("parent_id"),
     }, (table) => {
-      return [{
-        parentReference: foreignKey({
+      return [
+        foreignKey({
           columns: [table.parentId],
           foreignColumns: [table.id],
           name: "custom_fk"
         }),
-      }];
+      ];
     });
     ```
 
@@ -930,9 +930,9 @@ To declare multicolumn foreign keys you can use a dedicated `foreignKey` operato
       firstName: text("firstName"),
       lastName: text("lastName"),
     }, (table) => {
-      return {
-        pk: primaryKey({ columns: [table.firstName, table.lastName]}),
-      };
+      return [
+        primaryKey({ columns: [table.firstName, table.lastName]}),
+      ];
     });
 
     export const profile = pgTable("profile", {
@@ -940,13 +940,13 @@ To declare multicolumn foreign keys you can use a dedicated `foreignKey` operato
       userFirstName: text("user_first_name"),
       userLastName: text("user_last_name"),
     }, (table) => {
-      return [{
-        userReference: foreignKey({
+      return [
+        foreignKey({
           columns: [table.userFirstName, table.userLastName],
           foreignColumns: [user.firstName, user.lastName]
           name: "custom_fk"
         })
-      }]
+      ]
     })
     ```
 
@@ -1029,10 +1029,10 @@ Drizzle ORM provides API for both `index` and `unique index` declaration:
       name: text("name"),
       email: text("email"),
     }, (table) => {
-      return {
-        nameIdx: index("name_idx").on(table.name),
-        emailIdx: uniqueIndex("email_idx").on(table.email),
-      };
+      return [
+        index("name_idx").on(table.name),
+        uniqueIndex("email_idx").on(table.email),
+      ];
     });
     ```
     ```sql {5-6}


### PR DESCRIPTION
#433 updated these docs to the new signature in 0.36.0, where
```ts
...
  (table) => ({
    constraint: unique().on(table.something)
  })
)
```
becomes:
```ts
...,
  (table) => [
    unique().on(table.something)
  ]
)
```

but it left the `PgTableExtraConfig` in the array, which is incorrect and results in drizzle-kit not generating migrations. (i.e was updated to:
```ts
...,
  (table) => [{
    constraint: unique().on(table.something)
  }]
)
```
)

As per the [mentioned diff](https://github.com/drizzle-team/drizzle-orm/pull/3193/files#diff-8cc5eab297b00bd8fd753c57063cc3dd441af6c96b23dba32df67e0acfe3f961), I believe it should be `PgTableExtraConfigValue[]` not `PgTableExtraConfig[]`

Let me know if I've misunderstood this and thanks for your time 🤗 