### PR TITLE
Fix spelling mistakes in `docs/kit-overview.mdx`

### DIFF
--- a/src/content/docs/kit-overview.mdx
+++ b/src/content/docs/kit-overview.mdx
@@ -12,9 +12,9 @@ import Prerequisites from "@mdx/Prerequisites.astro"
 # Migrations with Drizzle Kit
 <Prerequisites>
 - Get started with Drizzle and `drizzle-kit` - [read here](/docs/get-started)
-- Drizzle schema foundamentals - [read here](/docs/sql-schema-declaration)
+- Drizzle schema fundamentals - [read here](/docs/sql-schema-declaration)
 - Database connection basics - [read here](/docs/connect-overview)
-- Drizzle migrations foundamentals - [read here](/docs/migrations)
+- Drizzle migrations fundamentals - [read here](/docs/migrations)
 </Prerequisites>
 
 
@@ -23,7 +23,7 @@ import Prerequisites from "@mdx/Prerequisites.astro"
   drizzle-kit
 </Npm>
 <Callout type="warning">
-Make sure to first go through Drizzle [get started](/docs/get-started) and [migration foundamentals](/docs/migrations) and pick SQL migration flow that suites your business needs best. 
+Make sure to first go through Drizzle [get started](/docs/get-started) and [migration fundamentals](/docs/migrations) and pick SQL migration flow that suites your business needs best. 
 </Callout>
 
 Based on your schema, Drizzle Kit let's you generate and run SQL migration files, 


### PR DESCRIPTION
Updated 3 instances of the word "foundamentals" to the correct spelling of "fundamentals"