### PR TITLE
Fix Incorrect Example for Defining Composite Primary Keys in Documentation

### DIFF
--- a/src/content/docs/indexes-constraints.mdx
+++ b/src/content/docs/indexes-constraints.mdx
@@ -629,10 +629,10 @@ Drizzle ORM provides a standalone `primaryKey` operator for that:
         authorId: integer("author_id"),
         bookId: integer("book_id"),
       }, (table) => {
-        return [{
-          pk: primaryKey({ columns: [table.bookId, table.authorId] }),
-          pkWithCustomName: primaryKey({ name: 'custom_name', columns: [table.bookId, table.authorId] }),
-        }];
+        return [
+          primaryKey({ columns: [table.bookId, table.authorId] }),
+          primaryKey({ name: 'custom_name', columns: [table.bookId, table.authorId] }),
+        ];
       });
       ```
 
@@ -642,7 +642,7 @@ Drizzle ORM provides a standalone `primaryKey` operator for that:
       CREATE TABLE IF NOT EXISTS "books_to_authors" (
         "author_id" integer,
         "book_id" integer,
-        PRIMARY KEY("book_id","author_id"),
+        CONSTRAINT "books_to_authors_book_id_author_id_pk" PRIMARY KEY("book_id","author_id"),
       );
 
       ALTER TABLE "books_to_authors" ADD CONSTRAINT "custom_name" PRIMARY KEY("book_id","author_id");

--- a/tests/snake.test.ts
+++ b/tests/snake.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from "vitest";
 import {
   gameSegments,
   mapSnake,
-} from "../components/landing/header/snake/mapSnake";
+} from "../src/ui/components/landing/snake/mapSnake";
 
 const gridHeight = 10;
 const gridWidth = 19;


### PR DESCRIPTION
This pull request fixes the incorrect example in the Drizzle ORM documentation for defining composite primary keys using the primaryKey operator. The current example mistakenly uses an object with keys pk and pkWithCustomName to define composite primary keys. This syntax does not work as intended and may lead to confusion for developers.

Changes Made
- Updated the composite primary key example to use the correct syntax:
- Returned an array of primaryKey definitions directly instead of wrapping them inside an object.
- Fixed incorrect component import in test files causing tests to fail

### Before Change (Incorrect):
```js
export const booksToAuthors = pgTable("books_to_authors", {
  authorId: integer("author_id"),
  bookId: integer("book_id"),
}, (table) => {
  return [{
    pk: primaryKey({ columns: [table.bookId, table.authorId] }),
    pkWithCustomName: primaryKey({ name: 'custom_name', columns: [table.bookId, table.authorId] }),
  }];
});
```

### After Fix:
```js
export const booksToAuthors = pgTable(
  "books_to_authors",
  {
    authorId: integer("author_id"),
    bookId: integer("book_id"),
  },
  (table) => {
    return [
      primaryKey({ columns: [table.bookId, table.authorId] }),
      primaryKey({ name: "custom_name", columns: [table.bookId, table.authorId] }),
    ];
  },
);
```

Closes #456