### PR TITLE
Move index.ts to src/db directory to align with docs

### DIFF
--- a/src/mdx/get-started/FileStructure.mdx
+++ b/src/mdx/get-started/FileStructure.mdx
@@ -7,8 +7,8 @@ This is the basic file structure of the project. In the `src/db` directory, we h
  ├ 📂 drizzle
  ├ 📂 src
  │   ├ 📂 db
+ │   │  ├ 📜 index.ts
  │   │  └ 📜 schema.ts
- │   └ 📜 index.ts
  ├ 📜 .env
  ├ 📜 drizzle.config.ts
  ├ 📜 package.json


### PR DESCRIPTION
This PR restructures the project to move the `index.ts` file from `src/` to `src/db`. This change aligns with the documentation, which states: "Create an index.ts file in the src/db directory and initialize the connection." 
Reference: https://orm.drizzle.team/docs/get-started/postgresql-new#:~:text=Create%20a%20schema.ts%20file%20in%20the%20src/db%20directory%20and%20declare%20your%20table%3A