### PR TITLE
nit: typo

### DIFF
--- a/src/mdx/LibsqlTable.mdx
+++ b/src/mdx/LibsqlTable.mdx
@@ -1,6 +1,6 @@
 |                          |                                                                                                                                           |
 | :----------------------- | :---------------------------------------------------------------------------------------------------------------------------------------- |
-| `@libsql/client`         | defaults to `node` import, automatically changes to `web` if `target` or `platofrm` is set for bundler, e.g. `esbuild --platform=browser` |
+| `@libsql/client`         | defaults to `node` import, automatically changes to `web` if `target` or `platform` is set for bundler, e.g. `esbuild --platform=browser` |
 | `@libsql/client/node`    | `node` compatible module, supports `:memory:`, `file`, `wss`, `http` and `turso` conneciton protocols                                     |
 | `@libsql/client/web`     | module for fullstack web frameworks like `next`, `nuxt`, `astro`, etc.                                                                    |
 | `@libsql/client/http`    | module for `http` and `https` connection protocols                                                                                        |


### PR DESCRIPTION
Small typo fix: `platofrm` should be `platform`.