### PR TITLE
Fix "let's" typos in Migrations

### DIFF
--- a/src/content/docs/migrations.mdx
+++ b/src/content/docs/migrations.mdx
@@ -54,7 +54,7 @@ It is perfect wether you work alone or in a team.
 
 <Callout collapsed="Expand details">
 That's a **database first** approach. You have your database schema as a **source of truth** and 
-Drizzle let's you pull database schema to TypeScript using [`drizzle-kit pull`](/docs/drizzle-kit-pull) command.
+Drizzle lets you pull database schema to TypeScript using [`drizzle-kit pull`](/docs/drizzle-kit-pull) command.
 
 <Section>
 ```
@@ -93,7 +93,7 @@ export const users = p.pgTable("users", {
 
 <Callout collapsed="Expand details">
 That's a **codebase first** approach. You have your TypeScript Drizzle schema as a **source of truth** and 
-Drizzle let's you push schema changes to the database using [`drizzle-kit push`](/docs/drizzle-kit-push) command.
+Drizzle lets you push schema changes to the database using [`drizzle-kit push`](/docs/drizzle-kit-push) command.
 
 That's the best approach for rapid prototyping and we've seen dozens of teams 
 and solo developers successfully using it as a primary migrations flow in their production applications.
@@ -142,7 +142,7 @@ Add column to `users` table
 
 <Callout collapsed="Expand details">
 That's a **codebase first** approach. You have your TypeScript Drizzle schema as a source of truth and 
-Drizzle let's you generate SQL migration files based on your schema changes with [`drizzle-kit generate`](/docs/drizzle-kit-generate)
+Drizzle lets you generate SQL migration files based on your schema changes with [`drizzle-kit generate`](/docs/drizzle-kit-generate)
 and then apply them to the database with [`drizzle-kit migrate`](/docs/drizzle-kit-migrate) commands. 
 <Section>
 ```typescript filename="src/schema.ts"
@@ -205,7 +205,7 @@ CREATE TABLE "users" (
 
 <Callout collapsed="Expand details">
 That's a **codebase first** approach. You have your TypeScript Drizzle schema as a source of truth and 
-Drizzle let's you generate SQL migration files based on your schema changes with [`drizzle-kit generate`](/docs/drizzle-kit-generate) and then 
+Drizzle lets you generate SQL migration files based on your schema changes with [`drizzle-kit generate`](/docs/drizzle-kit-generate) and then 
 you can apply them to the database during runtime of your application.
 
 This approach is widely used for **monolithic** applications when you apply database migrations 
@@ -284,7 +284,7 @@ await migrate(db);
 
 <Callout collapsed="Expand details">
 That's a **codebase first** approach. You have your TypeScript Drizzle schema as a source of truth and 
-Drizzle let's you generate SQL migration files based on your schema changes with [`drizzle-kit generate`](/docs/drizzle-kit-generate) and then 
+Drizzle lets you generate SQL migration files based on your schema changes with [`drizzle-kit generate`](/docs/drizzle-kit-generate) and then 
 you can apply them to the database either directly or via external migration tools.
 
 <Section>
@@ -359,7 +359,7 @@ CREATE TABLE "users" (
 
 <Callout collapsed="Expand details">
 That's a **codebase first** approach. You have your TypeScript Drizzle schema as a source of truth and 
-Drizzle let's you export SQL statements based on your schema changes with [`drizzle-kit export`](/docs/drizzle-kit-generate) and then 
+Drizzle lets you export SQL statements based on your schema changes with [`drizzle-kit export`](/docs/drizzle-kit-generate) and then 
 you can apply them to the database via external migration tools.
 
 <Section>


### PR DESCRIPTION
Corrects instances where "let's" was mistakenly used instead of "lets"