### PR TITLE
Update link to d1 batch API

### DIFF
--- a/src/content/docs/batch-api.mdx
+++ b/src/content/docs/batch-api.mdx
@@ -11,7 +11,7 @@ The transaction is controlled by the libSQL backend. If all of the statements ar
 the transaction is committed. If any of the statements fail, the entire transaction is rolled back and no changes are made.
 
 **D1 Batch API explanation**:
-_[source](https://developers.cloudflare.com/d1/platform/client-api/#batch-statements)_
+_[source](https://developers.cloudflare.com/d1/worker-api/d1-database/#batch)_
 
 > Batching sends multiple SQL statements inside a single call to the database. 
 This can have a huge performance impact as it reduces latency from network round trips to D1. 


### PR DESCRIPTION
New doc link is https://developers.cloudflare.com/d1/worker-api/d1-database/#batch instead of https://developers.cloudflare.com/d1/platform/client-api/#batch-statements