### PR TITLE
Update drizzle-kit-check.mdx

### DIFF
--- a/src/content/docs/drizzle-kit-check.mdx
+++ b/src/content/docs/drizzle-kit-check.mdx
@@ -80,5 +80,5 @@ yet you can provide all configuration options through CLI if necessary, e.g. in 
 <br/>
 <Npx>
 drizzle-kit check --dialect=postgresql
-drizzle-kit check --dialect=postgresql --our=./migrations-folder
+drizzle-kit check --dialect=postgresql --out=./migrations-folder
 </Npx>


### PR DESCRIPTION
fix typo: `our` -> `out` for the cli argument