### PR TITLE
Remove instances of deprecated third param in table definition

### DIFF
--- a/src/content/docs/extensions/pg.mdx
+++ b/src/content/docs/extensions/pg.mdx
@@ -58,11 +58,11 @@ Let's take a few examples of `pg_vector` indexes from the `pg_vector` docs and t
 
 const table = pgTable('items', {
     embedding: vector({ dimensions: 3 })
-}, (table) => ({
-    l2: index('l2_index').using('hnsw', table.embedding.op('vector_l2_ops'))
-    ip: index('ip_index').using('hnsw', table.embedding.op('vector_ip_ops'))
-    cosine: index('cosine_index').using('hnsw', table.embedding.op('vector_cosine_ops'))
-}))
+}, (table) => [
+  index('l2_index').using('hnsw', table.embedding.op('vector_l2_ops'))
+  index('ip_index').using('hnsw', table.embedding.op('vector_ip_ops'))
+  index('cosine_index').using('hnsw', table.embedding.op('vector_cosine_ops'))
+])
 ```
 
 #### L1 distance, Hamming distance and Jaccard distance - added in pg_vector 0.7.0 version
@@ -74,11 +74,11 @@ const table = pgTable('items', {
 
 const table = pgTable('table', {
     embedding: vector({ dimensions: 3 })
-}, (table) => ({
-    l1: index('l1_index').using('hnsw', table.embedding.op('vector_l1_ops'))
-    hamming: index('hamming_index').using('hnsw', table.embedding.op('bit_hamming_ops'))
-    bit: index('bit_jaccard_index').using('hnsw', table.embedding.op('bit_jaccard_ops'))
-}))
+}, (table) => [
+  index('l1_index').using('hnsw', table.embedding.op('vector_l1_ops'))
+  index('hamming_index').using('hnsw', table.embedding.op('bit_hamming_ops'))
+  index('bit_jaccard_index').using('hnsw', table.embedding.op('bit_jaccard_ops'))
+])
 ```
 
 #### Helper Functions
@@ -192,7 +192,7 @@ With the available Drizzle indexes API, you should be able to write any indexes 
 
 const table = pgTable('table', {
   	geo: geometry({ type: 'point' }),
-}, (table) => ({
-    gist: index('custom_idx').using('gist', table.geo)
-}))
+}, (table) => [
+  index('custom_idx').using('gist', table.geo)
+])
 ```

--- a/src/content/docs/generated-columns.mdx
+++ b/src/content/docs/generated-columns.mdx
@@ -127,9 +127,9 @@ Generated columns can be especially useful for:
           (): SQL => sql`to_tsvector('english', ${test.content})`
         ),
       },
-      (t) => ({
-        idx: index("idx_content_search").using("gin", t.contentSearch),
-      })
+      (t) => [
+        index("idx_content_search").using("gin", t.contentSearch)
+      ]
     );
     ```
     ```sql {4}

--- a/src/content/docs/guides/cursor-based-pagination.mdx
+++ b/src/content/docs/guides/cursor-based-pagination.mdx
@@ -203,13 +203,12 @@ Make sure to create indices for the columns that you use for cursor to make quer
 import { index, ...imports } from 'drizzle-orm/pg-core';
 
 export const users = pgTable('users', {
-// columns declaration
+  // columns declaration
 },
-(t) => ({
-  firstNameIndex: index('first_name_index').on(t.firstName).asc(),
-  firstNameAndIdIndex: index('first_name_and_id_index').on(t.firstName, t.id).asc(),
-}),
-);
+(t) => [
+  index('first_name_index').on(t.firstName).asc(),
+  index('first_name_and_id_index').on(t.firstName, t.id).asc(),
+]);
 ```
 
 ```sql

--- a/src/content/docs/guides/postgis-geometry-point.mdx
+++ b/src/content/docs/guides/postgis-geometry-point.mdx
@@ -44,9 +44,9 @@ This is how you can create table with `geometry` datatype and spatial index in D
       name: text('name').notNull(),
       location: geometry('location', { type: 'point', mode: 'xy', srid: 4326 }).notNull(),
     },
-    (t) => ({
-      spatialIndex: index('spatial_index').using('gist', t.location),
-    }),
+    (t) => [
+      index('spatial_index').using('gist', t.location),
+    ]
   );
   ```
   </CodeTab>

--- a/src/content/docs/guides/postgresql-full-text-search.mdx
+++ b/src/content/docs/guides/postgresql-full-text-search.mdx
@@ -69,10 +69,9 @@ As for now, Drizzle doesn't support `tsvector` type natively, so you need to con
       id: serial('id').primaryKey(),
       title: text('title').notNull(),
     },
-    (table) => ({
-      titleSearchIndex: index('title_search_index')
-      .using('gin', sql`to_tsvector('english', ${table.title})`),
-    }),
+    (table) => [
+      index('title_search_index').using('gin', sql`to_tsvector('english', ${table.title})`),
+    ]
   );
   ```
   </CodeTab>
@@ -235,15 +234,15 @@ To implement full-text search on multiple columns, you can create index on multi
       title: text('title').notNull(),
       description: text('description').notNull(),
     },
-    (table) => ({
-      searchIndex: index('search_index').using(
+    (table) => [
+      index('search_index').using(
         'gin',
         sql`(
             setweight(to_tsvector('english', ${table.title}), 'A') ||
             setweight(to_tsvector('english', ${table.description}), 'B')
         )`,
       ),
-    }),
+    ],
   );
   ```
   </CodeTab>

--- a/src/content/docs/guides/unique-case-insensitive-email.mdx
+++ b/src/content/docs/guides/unique-case-insensitive-email.mdx
@@ -35,10 +35,10 @@ Drizzle has simple and flexible API, which lets you easily create such an index 
       name: text('name').notNull(),
       email: text('email').notNull(),
     },
-    (table) => ({
-   // emailUniqueIndex: uniqueIndex('emailUniqueIndex').on(sql`lower(${table.email})`),
-      emailUniqueIndex: uniqueIndex('emailUniqueIndex').on(lower(table.email)),
-    }),
+    (table) => [
+      // uniqueIndex('emailUniqueIndex').on(sql`lower(${table.email})`),
+      uniqueIndex('emailUniqueIndex').on(lower(table.email)),
+    ],
   );
 
   // custom lower function
@@ -98,10 +98,10 @@ Drizzle has simple and flexible API, which lets you easily create such an index 
       name: varchar('name', { length: 255 }).notNull(),
       email: varchar('email', { length: 255 }).notNull(),
     },
-    (table) => ({
-   // emailUniqueIndex: uniqueIndex('emailUniqueIndex').on(sql`(lower(${table.email}))`),
-      emailUniqueIndex: uniqueIndex('emailUniqueIndex').on(lower(table.email)),
-    }),
+    (table) => [
+      // uniqueIndex('emailUniqueIndex').on(sql`(lower(${table.email}))`),
+      uniqueIndex('emailUniqueIndex').on(lower(table.email)),
+    ]
   );
 
   // custom lower function
@@ -166,10 +166,10 @@ Drizzle has simple and flexible API, which lets you easily create such an index 
       name: text('name').notNull(),
       email: text('email').notNull(),
     },
-    (table) => ({
-      // emailUniqueIndex: uniqueIndex('emailUniqueIndex').on(sql`lower(${table.email})`),
-      emailUniqueIndex: uniqueIndex('emailUniqueIndex').on(lower(table.email)),
-    }),
+    (table) => [
+      // uniqueIndex('emailUniqueIndex').on(sql`lower(${table.email})`),
+      uniqueIndex('emailUniqueIndex').on(lower(table.email)),
+    ]
   );
 
   // custom lower function

--- a/src/content/docs/guides/vector-similarity-search.mdx
+++ b/src/content/docs/guides/vector-similarity-search.mdx
@@ -54,9 +54,9 @@ To perform similarity search, you need to create a table with a vector column an
       url: text('url').notNull(),
       embedding: vector('embedding', { dimensions: 1536 }),
     },
-    (table) => ({
-      embeddingIndex: index('embeddingIndex').using('hnsw', table.embedding.op('vector_cosine_ops')),
-    }),
+    (table) => [
+      index('embeddingIndex').using('hnsw', table.embedding.op('vector_cosine_ops')),
+    ]
   );
   ```
   </CodeTab>

--- a/src/content/docs/indexes-constraints.mdx
+++ b/src/content/docs/indexes-constraints.mdx
@@ -216,18 +216,18 @@ A `PRIMARY KEY` constraint automatically has a `UNIQUE` constraint.
       export const composite = pgTable('composite_example', {
         id: integer('id'),
         name: text('name'),
-      }, (t) => [{
-        unq: unique().on(t.id, t.name),
-        unq2: unique('custom_name').on(t.id, t.name)
-      }]);
+      }, (t) => [
+        unique().on(t.id, t.name),
+        unique('custom_name').on(t.id, t.name)
+      ]);
 
       // In Postgres 15.0+ NULLS NOT DISTINCT is available
       // This example demonstrates both available usages
       export const userNulls = pgTable('user_nulls_example', {
         id: integer('id').unique("custom_name", { nulls: 'not distinct' }),
-      }, (t) => [{
-        unq: unique().on(t.id).nullsNotDistinct()
-      }]);
+      }, (t) => [
+        unique().on(t.id).nullsNotDistinct()
+      ]);
       ```
 
       ```sql
@@ -273,10 +273,10 @@ A `PRIMARY KEY` constraint automatically has a `UNIQUE` constraint.
       export const composite = mysqlTable('composite_example', {
         id: int('id'),
         name: varchar('name', { length: 256 }),
-      }, (t) => ({
-        unq: unique().on(t.id, t.name),
-        unq2: unique('custom_name').on(t.id, t.name)
-      }));
+      }, (t) => [
+        unique().on(t.id, t.name),
+        unique('custom_name').on(t.id, t.name)
+      ]);
       ```
 
       ```sql
@@ -316,10 +316,10 @@ A `PRIMARY KEY` constraint automatically has a `UNIQUE` constraint.
       export const composite = sqliteTable('composite_example', {
         id: int('id'),
         name: text('name'),
-      }, (t) => ({
-        unq: unique().on(t.id, t.name),
-        unq2: unique('custom_name').on(t.id, t.name)
-      }));
+      }, (t) => [
+        unique().on(t.id, t.name),
+        unique('custom_name').on(t.id, t.name)
+      ]);
       ```
 
       ```sql
@@ -360,10 +360,10 @@ A `PRIMARY KEY` constraint automatically has a `UNIQUE` constraint.
       export const composite = singlestoreTable('composite_example', {
         id: int('id'),
         name: varchar('name', { length: 256 }),
-      }, (t) => ({
-        unq: unique().on(t.id, t.name),
-        unq2: unique('custom_name').on(t.id, t.name)
-      }));
+      }, (t) => [
+        unique().on(t.id, t.name),
+        unique('custom_name').on(t.id, t.name)
+      ]);
       ```
 
       ```sql
@@ -411,9 +411,9 @@ If you define a `CHECK` constraint on a table it can limit the values in certain
           username: text().notNull(),
           age: integer(),
         },
-        (table) => [{
-          checkConstraint: check("age_check1", sql`${table.age} > 21`),
-        }]
+        (table) => [
+          check("age_check1", sql`${table.age} > 21`),
+        ]
       );
       ```
       ```sql
@@ -440,9 +440,9 @@ If you define a `CHECK` constraint on a table it can limit the values in certain
           username: text().notNull(),
           age: int(),
         },
-        (table) => ({
-          checkConstraint: check("age_check1", sql`${table.age} > 21`),
-        })
+        (table) => [
+          check("age_check1", sql`${table.age} > 21`)
+        ]
       );
       ```
       ```sql
@@ -469,9 +469,9 @@ If you define a `CHECK` constraint on a table it can limit the values in certain
           username: text().notNull(),
           age: int(),
         },
-        (table) => ({
-          checkConstraint: check("age_check1", sql`${table.age} > 21`),
-        })
+        (table) => [
+          check("age_check1", sql`${table.age} > 21`)
+        ]
       );
       ```
       ```sql
@@ -628,12 +628,11 @@ Drizzle ORM provides a standalone `primaryKey` operator for that:
       export const booksToAuthors = pgTable("books_to_authors", {
         authorId: integer("author_id"),
         bookId: integer("book_id"),
-      }, (table) => {
-        return [{
-          pk: primaryKey({ columns: [table.bookId, table.authorId] }),
-          pkWithCustomName: primaryKey({ name: 'custom_name', columns: [table.bookId, table.authorId] }),
-        }];
-      });
+      }, (table) => [
+        primaryKey({ columns: [table.bookId, table.authorId] }),
+        // Or PK with custom name
+        primaryKey({ name: 'custom_name', columns: [table.bookId, table.authorId] }),
+      ]);
       ```
 
       ```sql {6, 9}
@@ -668,12 +667,11 @@ Drizzle ORM provides a standalone `primaryKey` operator for that:
       export const booksToAuthors = mysqlTable("books_to_authors", {
         authorId: int("author_id"),
         bookId: int("book_id"),
-      }, (table) => {
-        return {
-          pk: primaryKey({ columns: [table.bookId, table.authorId] }),
-          pkWithCustomName: primaryKey({ name: 'custom_name', columns: [table.bookId, table.authorId] }),
-        };
-      });
+      }, (table) => [
+        primaryKey({ columns: [table.bookId, table.authorId] }),
+        // Or PK with custom name
+        primaryKey({ name: 'custom_name', columns: [table.bookId, table.authorId] })
+      ]);
       ```
 
       ```sql {6}
@@ -706,12 +704,11 @@ Drizzle ORM provides a standalone `primaryKey` operator for that:
       export const bookToAuthor = sqliteTable("book_to_author", {
         authorId: integer("author_id"),
         bookId: integer("book_id"),
-      }, (table) => {
-        return {
-          pk: primaryKey({ columns: [table.bookId, table.authorId] }),
-          pkWithCustomName: primaryKey({ name: 'custom_name', columns: [table.bookId, table.authorId] }),
-        };
-      });
+      }, (table) => [
+        primaryKey({ columns: [table.bookId, table.authorId] }),
+        // Or PK with custom name
+        primaryKey({ name: 'custom_name', columns: [table.bookId, table.authorId] })
+      ]);
       ```
       ```sql {6}
       ...
@@ -743,12 +740,11 @@ Drizzle ORM provides a standalone `primaryKey` operator for that:
       export const booksToAuthors = singlestoreTable("books_to_authors", {
         authorId: int("author_id"),
         bookId: int("book_id"),
-      }, (table) => {
-        return {
-          pk: primaryKey({ columns: [table.bookId, table.authorId] }),
-          pkWithCustomName: primaryKey({ name: 'custom_name', columns: [table.bookId, table.authorId] }),
-        };
-      });
+      }, (table) => [
+        primaryKey({ columns: [table.bookId, table.authorId] }),
+        // Or PK with custom name
+        primaryKey({ name: 'custom_name', columns: [table.bookId, table.authorId] }),
+      ]);
       ```
 
       ```sql {6}
@@ -850,15 +846,13 @@ set return type for reference callback or use a standalone `foreignKey` operator
       id: serial("id"),
       name: text("name"),
       parentId: integer("parent_id"),
-    }, (table) => {
-      return [{
-        parentReference: foreignKey({
-          columns: [table.parentId],
-          foreignColumns: [table.id],
-          name: "custom_fk"
-        }),
-      }];
-    });
+    }, (table) => [
+      foreignKey({
+        columns: [table.parentId],
+        foreignColumns: [table.id],
+        name: "custom_fk"
+      })
+    ]);
     ```
 
   </Tab>
@@ -877,15 +871,13 @@ set return type for reference callback or use a standalone `foreignKey` operator
       id: int("id").primaryKey().autoincrement(),
       name: text("name"),
       parentId: int("parent_id")
-    }, (table) => {
-      return {
-        parentReference: foreignKey({
-          columns: [table.parentId],
-          foreignColumns: [table.id],
-          name: "custom_fk"
-        }),
-      };
-    });
+    }, (table) => [
+      foreignKey({
+        columns: [table.parentId],
+        foreignColumns: [table.id],
+        name: "custom_fk"
+      })
+    ]);
     ```
 
   </Tab>
@@ -904,15 +896,13 @@ set return type for reference callback or use a standalone `foreignKey` operator
       id: integer("id").primaryKey({ autoIncrement: true }),
       name: text("name"),
       parentId: integer("parent_id"),
-    }, (table) => {
-      return {
-        parentReference: foreignKey({
-          columns: [table.parentId],
-          foreignColumns: [table.id],
-          name: "custom_fk"
-        }),
-      };
-    });
+    }, (table) => [
+      foreignKey({
+        columns: [table.parentId],
+        foreignColumns: [table.id],
+        name: "custom_fk"
+      })
+    ]);
     ```
 
   </Tab>
@@ -929,25 +919,21 @@ To declare multicolumn foreign keys you can use a dedicated `foreignKey` operato
     export const user = pgTable("user", {
       firstName: text("firstName"),
       lastName: text("lastName"),
-    }, (table) => {
-      return {
-        pk: primaryKey({ columns: [table.firstName, table.lastName]}),
-      };
-    });
+    }, (table) => [
+      primaryKey({ columns: [table.firstName, table.lastName]})
+    ]);
 
     export const profile = pgTable("profile", {
       id: serial("id").primaryKey(),
       userFirstName: text("user_first_name"),
       userLastName: text("user_last_name"),
-    }, (table) => {
-      return [{
-        userReference: foreignKey({
-          columns: [table.userFirstName, table.userLastName],
-          foreignColumns: [user.firstName, user.lastName]
-          name: "custom_fk"
-        })
-      }]
-    })
+    }, (table) => [
+      foreignKey({
+        columns: [table.userFirstName, table.userLastName],
+        foreignColumns: [user.firstName, user.lastName],
+        name: "custom_fk"
+      })
+    ])
     ```
 
   </Tab>
@@ -958,25 +944,21 @@ To declare multicolumn foreign keys you can use a dedicated `foreignKey` operato
     export const user = mysqlTable("user", {
       firstName: text("firstName"),
       lastName: text("lastName"),
-    }, (table) => {
-      return {
-        pk: primaryKey({ columns: [table.firstName, table.lastName]}),
-      };
-    });
+    }, (table) => [
+      primaryKey({ columns: [table.firstName, table.lastName]})
+    ]);
 
     export const profile = mysqlTable("profile", {
       id: int("id").autoincrement().primaryKey(),
       userFirstName: text("user_first_name"),
       userLastName: text("user_last_name"),
-    }, (table) => {
-      return {
-        userReference: foreignKey({
-          columns: [table.userFirstName, table.userLastName],
-          foreignColumns: [user.firstName, user.lastName],
-          name: "custom_name"
-        })
-      }
-    });
+    }, (table) => [
+      foreignKey({
+        columns: [table.userFirstName, table.userLastName],
+        foreignColumns: [user.firstName, user.lastName],
+        name: "custom_name"
+      })
+    ]);
     ```
 
   </Tab>
@@ -987,25 +969,21 @@ To declare multicolumn foreign keys you can use a dedicated `foreignKey` operato
     export const user = sqliteTable("user", {
       firstName: text("firstName"),
       lastName: text("lastName"),
-    }, (table) => {
-      return {
-        pk: primaryKey({ columns: [table.firstName, table.lastName]}),
-      };
-    });
+    }, (table) => [
+      primaryKey({ columns: [table.firstName, table.lastName]})
+    ]);
 
     export const profile = sqliteTable("profile", {
       id: integer("id").primaryKey({ autoIncrement: true }),
       userFirstName: text("user_first_name"),
       userLastName: text("user_last_name"),
-    }, (table) => {
-      return {
-        userReference: foreignKey({
-          columns: [table.userFirstName, table.userLastName],
-          foreignColumns: [user.firstName, user.lastName],
-          name: "custom_name"
-        })
-      }
-    });
+    }, (table) => [
+      foreignKey({
+        columns: [table.userFirstName, table.userLastName],
+        foreignColumns: [user.firstName, user.lastName],
+        name: "custom_name"
+      })
+    ]);
     ```
 
   </Tab>
@@ -1028,12 +1006,10 @@ Drizzle ORM provides API for both `index` and `unique index` declaration:
       id: serial("id").primaryKey(),
       name: text("name"),
       email: text("email"),
-    }, (table) => {
-      return {
-        nameIdx: index("name_idx").on(table.name),
-        emailIdx: uniqueIndex("email_idx").on(table.email),
-      };
-    });
+    }, (table) => [
+      index("name_idx").on(table.name),
+      uniqueIndex("email_idx").on(table.email)
+    ]);
     ```
     ```sql {5-6}
     CREATE TABLE "user" (
@@ -1078,12 +1054,10 @@ index('name')
       id: int("id").primaryKey().autoincrement(),
       name: text("name"),
       email: text("email"),
-    }, (table) => {
-      return {
-        nameIdx: index("name_idx").on(table.name),
-        emailIdx: uniqueIndex("email_idx").on(table.email),
-      };
-    });
+    }, (table) => [
+      index("name_idx").on(table.name),
+      uniqueIndex("email_idx").on(table.email),
+    ]);
     ```
     ```sql {5-6}
     CREATE TABLE `user` (
@@ -1118,12 +1092,10 @@ index('name')
       id: integer("id").primaryKey({ autoIncrement: true }),
       name: text("name"),
       email: text("email"),
-    }, (table) => {
-      return {
-        nameIdx: index("name_idx").on(table.name),
-        emailIdx: uniqueIndex("email_idx").on(table.email),
-      };
-    });
+    }, (table) => [
+      index("name_idx").on(table.name),
+      uniqueIndex("email_idx").on(table.email),
+    ]);
     ```
     ```sql {5-6}
     CREATE TABLE `user` (
@@ -1153,12 +1125,10 @@ index('name')
       id: int("id").primaryKey().autoincrement(),
       name: text("name"),
       email: text("email"),
-    }, (table) => {
-      return {
-        nameIdx: index("name_idx").on(table.name),
-        emailIdx: uniqueIndex("email_idx").on(table.email),
-      };
-    });
+    }, (table) => [
+      index("name_idx").on(table.name),
+      uniqueIndex("email_idx").on(table.email),
+    ]);
     ```
     ```sql {5-6}
     CREATE TABLE `user` (

--- a/src/content/docs/migrate/migrate-from-prisma.mdx
+++ b/src/content/docs/migrate/migrate-from-prisma.mdx
@@ -287,11 +287,9 @@ export const orderDetails = pgTable(
       .references(() => products.id, { onDelete: 'restrict', onUpdate: 'cascade' }),
     quantity: integer('quantity').notNull(),
   },
-  (table) => {
-    return {
-      orderDetailsPkey: primaryKey({ columns: [table.orderId, table.productId], name: 'order_details_pkey' }),
-    };
-  },
+  (table) => [
+    primaryKey({ columns: [table.orderId, table.productId], name: 'order_details_pkey' })
+  ]
 );
 ```
 

--- a/src/content/docs/migrate/migrate-from-sequelize.mdx
+++ b/src/content/docs/migrate/migrate-from-sequelize.mdx
@@ -480,11 +480,9 @@ export const orderDetails = pgTable(
       .references(() => products.id, { onDelete: 'cascade', onUpdate: 'cascade' }),
     quantity: integer('quantity').notNull(),
   },
-  (table) => {
-    return {
-      orderDetailsPkey: primaryKey({ columns: [table.orderId, table.productId], name: 'order_details_pkey' }),
-    };
-  },
+  (table) => [
+    primaryKey({ columns: [table.orderId, table.productId], name: 'order_details_pkey' })
+  ]
 );
 ```
 

--- a/src/content/docs/migrate/migrate-from-typeorm.mdx
+++ b/src/content/docs/migrate/migrate-from-typeorm.mdx
@@ -307,14 +307,12 @@ export const orderDetails = pgTable(
       .references(() => products.id),
     quantity: integer('quantity').notNull(),
   },
-  (table) => {
-    return {
-      pkE08Ee153Eb9C98Ee497C1D1287E: primaryKey({
-        columns: [table.orderId, table.productId],
-        name: 'PK_e08ee153eb9c98ee497c1d1287e',
-      }),
-    };
-  },
+  (table) => [
+    primaryKey({
+      columns: [table.orderId, table.productId],
+      name: 'PK_e08ee153eb9c98ee497c1d1287e',
+    })
+  ],
 );
 ```
 

--- a/src/content/docs/relations.mdx
+++ b/src/content/docs/relations.mdx
@@ -216,9 +216,9 @@ export const usersToGroups = pgTable(
       .notNull()
       .references(() => groups.id),
   },
-  (t) => ({
-    pk: primaryKey({ columns: [t.userId, t.groupId] }),
-  }),
+  (t) => [
+		primaryKey({ columns: [t.userId, t.groupId] })
+	],
 );
 
 export const usersToGroupsRelations = relations(usersToGroups, ({ one }) => ({
@@ -357,16 +357,15 @@ export const posts = pgTable('posts', {
 	id: serial('id').primaryKey(),
 	name: text('name'),
 	author: integer('author').notNull(),
-}, (table) => ({
-		fk: foreignKey({
-			name: "author_fk",
-			columns: [table.author],
-			foreignColumns: [users.id],
-		})
-			.onDelete('cascade')
-			.onUpdate('cascade')
-	}),
-);
+}, (table) => [
+	foreignKey({
+		name: "author_fk",
+		columns: [table.author],
+		foreignColumns: [users.id],
+	})
+		.onDelete('cascade')
+		.onUpdate('cascade')
+]);
 ```
 
 ### Disambiguating relations

--- a/src/content/docs/rqb.mdx
+++ b/src/content/docs/rqb.mdx
@@ -185,9 +185,9 @@ await db.query.users.findMany(...);
 		id: serial('id').primaryKey(),
 		userId: integer('user_id').notNull().references(() => users.id),
 		groupId: integer('group_id').notNull().references(() => groups.id),
-	}, (t) => ({
-		pk: primaryKey(t.userId, t.groupId),
-	}));
+	}, (t) => [
+		primaryKey(t.userId, t.groupId)
+	]);
 
 	export const usersToGroupsRelations = relations(usersToGroups, ({ one }) => ({
 		group: one(groups, { fields: [usersToGroups.groupId], references: [groups.id] }),

--- a/src/content/docs/sql-schema-declaration.mdx
+++ b/src/content/docs/sql-schema-declaration.mdx
@@ -354,11 +354,9 @@ export const users = table(
     invitee: t.integer().references((): AnyPgColumn => users.id),
     role: rolesEnum().default("guest"),
   },
-  (table) => {
-    return {
-      emailIndex: t.uniqueIndex("email_idx").on(table.email),
-    };
-  }
+  (table) => [
+    t.uniqueIndex("email_idx").on(table.email)
+  ]
 );
 
 export const posts = table(
@@ -369,12 +367,10 @@ export const posts = table(
     title: t.varchar({ length: 256 }),
     ownerId: t.integer("owner_id").references(() => users.id),
   },
-  (table) => {
-    return {
-      slugIndex: t.uniqueIndex("slug_idx").on(table.slug),
-      titleIndex: t.index("title_idx").on(table.title),
-    };
-  }
+  (table) => [
+    t.uniqueIndex("slug_idx").on(table.slug),
+    t.index("title_idx").on(table.title),
+  ]
 );
 
 export const comments = table("comments", {
@@ -399,11 +395,9 @@ export const users = table(
     invitee: t.int().references((): AnyMySqlColumn => users.id),
     role: t.mysqlEnum(["guest", "user", "admin"]).default("guest"),
   },
-  (table) => {
-    return {
-      emailIndex: t.uniqueIndex("email_idx").on(table.email),
-    };
-  }
+  (table) => [
+    t.uniqueIndex("email_idx").on(table.email)
+  ]
 );
 
 export const posts = table(
@@ -414,12 +408,10 @@ export const posts = table(
     title: t.varchar({ length: 256 }),
     ownerId: t.int("owner_id").references(() => users.id),
   },
-  (table) => {
-    return {
-      slugIndex: t.uniqueIndex("slug_idx").on(table.slug),
-      titleIndex: t.index("title_idx").on(table.title),
-    };
-  }
+  (table) => [
+    t.uniqueIndex("slug_idx").on(table.slug),
+    t.index("title_idx").on(table.title),
+  ]
 );
 
 export const comments = table("comments", {
@@ -444,11 +436,9 @@ export const users = table(
     invitee: t.int().references((): AnySQLiteColumn => users.id),
     role: t.text().$type<"guest" | "user" | "admin">().default("guest"),
   },
-  (table) => {
-    return {
-      emailIndex: t.uniqueIndex("email_idx").on(table.email),
-    };
-  }
+  (table) => [
+    t.uniqueIndex("email_idx").on(table.email)
+  ]
 );
 
 export const posts = table(
@@ -459,12 +449,10 @@ export const posts = table(
     title: t.text(),
     ownerId: t.int("owner_id").references(() => users.id),
   },
-  (table) => {
-    return {
-      slugIndex: t.uniqueIndex("slug_idx").on(table.slug),
-      titleIndex: t.index("title_idx").on(table.title),
-    };
-  }
+  (table) => [
+    t.uniqueIndex("slug_idx").on(table.slug),
+    t.index("title_idx").on(table.title),
+  ]
 );
 
 export const comments = table("comments", {

--- a/src/mdx/get-started/mysql/IntrospectMySQL.mdx
+++ b/src/mdx/get-started/mysql/IntrospectMySQL.mdx
@@ -45,13 +45,11 @@ export const usersTable = mysqlTable(
     age: int().notNull(),
     email: varchar({ length: 255 }).notNull(),
   },
-  (table) => {
-    return {
-      usersTableId: primaryKey({ columns: [table.id], name: 'users_table_id' }),
-      id: unique('id').on(table.id),
-      usersTableEmailUnique: unique('users_table_email_unique').on(table.email),
-    };
-  },
+  (table) => [
+    primaryKey({ columns: [table.id], name: 'users_table_id' }),
+    unique('id').on(table.id),
+    unique('users_table_email_unique').on(table.email),
+  ],
 );
 ```
 

--- a/src/mdx/get-started/mysql/UpdateSchema.mdx
+++ b/src/mdx/get-started/mysql/UpdateSchema.mdx
@@ -22,12 +22,10 @@ export const usersTable = mysqlTable(
     email: varchar({ length: 255 }).notNull(),
     phone: varchar({ length: 255 }),
   },
-  (table) => {
-    return {
-      usersTableId: primaryKey({ columns: [table.id], name: 'users_table_id' }),
-      id: unique('id').on(table.id),
-      usersTableEmailUnique: unique('users_table_email_unique').on(table.email),
-    };
-  },
+  (table) => [
+    primaryKey({ columns: [table.id], name: 'users_table_id' }),
+    unique('id').on(table.id),
+    unique('users_table_email_unique').on(table.email),
+  ],
 );
 ```

--- a/src/mdx/get-started/postgresql/IntrospectPostgreSQL.mdx
+++ b/src/mdx/get-started/postgresql/IntrospectPostgreSQL.mdx
@@ -32,12 +32,9 @@ export const users = pgTable("users", {
 	name: varchar({ length: 255 }).notNull(),
 	age: integer().notNull(),
 	email: varchar({ length: 255 }).notNull(),
-},
-(table) => {
-	return {
-		usersEmailUnique: unique("users_email_unique").on(table.email),
-	}
-});
+}, (table) => [
+	unique("users_email_unique").on(table.email)
+]);
 ```
 
 Learn more about introspection in the [documentation](/docs/drizzle-kit-pull).

--- a/src/mdx/get-started/postgresql/UpdateSchema.mdx
+++ b/src/mdx/get-started/postgresql/UpdateSchema.mdx
@@ -10,10 +10,7 @@ export const users = pgTable("users", {
 	age: integer().notNull(),
 	email: varchar({ length: 255 }).notNull(),
   phone: varchar(),
-},
-(table) => {
-	return {
-		usersEmailUnique: unique("users_email_unique").on(table.email),
-	}
-});
+}, (table) => [
+	unique("users_email_unique").on(table.email)
+]);
 ```

--- a/src/mdx/get-started/singlestore/IntrospectSingleStore.mdx
+++ b/src/mdx/get-started/singlestore/IntrospectSingleStore.mdx
@@ -44,13 +44,11 @@ export const usersTable = singlestoreTable(
     age: int().notNull(),
     email: varchar({ length: 255 }).notNull(),
   },
-  (table) => {
-    return {
-      usersTableId: primaryKey({ columns: [table.id], name: 'users_table_id' }),
-      id: unique('id').on(table.id),
-      usersTableEmailUnique: unique('users_table_email_unique').on(table.email),
-    };
-  },
+  (table) => [
+    primaryKey({ columns: [table.id], name: 'users_table_id' }),
+    unique('id').on(table.id),
+    unique('users_table_email_unique').on(table.email),
+  ],
 );
 ```
 

--- a/src/mdx/get-started/singlestore/UpdateSchema.mdx
+++ b/src/mdx/get-started/singlestore/UpdateSchema.mdx
@@ -21,12 +21,10 @@ export const usersTable = singlestoreTable(
     email: varchar({ length: 255 }).notNull(),
     phone: varchar({ length: 255 }),
   },
-  (table) => {
-    return {
-      usersTableId: primaryKey({ columns: [table.id], name: 'users_table_id' }),
-      id: unique('id').on(table.id),
-      usersTableEmailUnique: unique('users_table_email_unique').on(table.email),
-    };
-  },
+  (table) => [
+    primaryKey({ columns: [table.id], name: 'users_table_id' }),
+    unique('id').on(table.id),
+    unique('users_table_email_unique').on(table.email),
+  ],
 );
 ```

--- a/src/mdx/get-started/sqlite/IntrospectSqlite.mdx
+++ b/src/mdx/get-started/sqlite/IntrospectSqlite.mdx
@@ -39,11 +39,9 @@ export const usersTable = sqliteTable(
     age: integer().notNull(),
     email: text().notNull(),
   },
-  (table) => {
-    return {
-      emailUnique: uniqueIndex("users_table_email_unique").on(table.email),
-    };
-  }
+  (table) => [
+    uniqueIndex("users_table_email_unique").on(table.email)
+  ]
 );
 ```
 

--- a/src/mdx/get-started/sqlite/UpdateSchema.mdx
+++ b/src/mdx/get-started/sqlite/UpdateSchema.mdx
@@ -18,10 +18,8 @@ export const usersTable = sqliteTable(
     email: text().notNull(),
     phone: text(),
   },
-  (table) => {
-    return {
-      emailUnique: uniqueIndex("users_table_email_unique").on(table.email),
-    };
-  }
+  (table) => [
+    uniqueIndex("users_table_email_unique").on(table.email)
+  ]
 );
 ```


### PR DESCRIPTION
There has been a decent amount of confusion surrounding the deprecation of the third param of tables when being defined as objects, mainly due to the documentation not being up to date with that. This PR fixes that.