### PR TITLE
Fix the location to create the index.ts file in the get-started examples

### DIFF
--- a/src/mdx/get-started/mysql/ConnectMySQL.mdx
+++ b/src/mdx/get-started/mysql/ConnectMySQL.mdx
@@ -1,7 +1,7 @@
 import Callout from '@mdx/Callout.astro';
 import CodeTabs from "@mdx/CodeTabs.astro";
 
-Create a `index.ts` file in the `src/db` directory and initialize the connection:
+Create a `index.ts` file in the `src` directory and initialize the connection:
 
 <CodeTabs items={['mysql2', 'mysql2 with config', 'your mysql2 driver']}>
 ```typescript copy

--- a/src/mdx/get-started/mysql/ConnectPlanetScale.mdx
+++ b/src/mdx/get-started/mysql/ConnectPlanetScale.mdx
@@ -1,4 +1,4 @@
-Create a `index.ts` file in the `src/db` directory and initialize the connection:
+Create a `index.ts` file in the `src` directory and initialize the connection:
 
 ```typescript copy
 import { drizzle } from "drizzle-orm/planetscale-serverless";

--- a/src/mdx/get-started/mysql/ConnectTiDB.mdx
+++ b/src/mdx/get-started/mysql/ConnectTiDB.mdx
@@ -1,4 +1,4 @@
-Create a `index.ts` file in the `src/db` directory and initialize the connection:
+Create a `index.ts` file in the `src` directory and initialize the connection:
 
 ```typescript copy
 import { drizzle } from 'drizzle-orm/tidb-serverless';

--- a/src/mdx/get-started/postgresql/ConnectNeon.mdx
+++ b/src/mdx/get-started/postgresql/ConnectNeon.mdx
@@ -2,7 +2,7 @@ import Callout from '@mdx/Callout.astro';
 import CodeTabs from "@mdx/CodeTabs.astro";
 import Section from "@mdx/Section.astro";
 
-Create a `index.ts` file in the `src/db` directory and initialize the connection:
+Create a `index.ts` file in the `src` directory and initialize the connection:
 
 ```typescript
 import { drizzle } from 'drizzle-orm/neon-http';

--- a/src/mdx/get-started/postgresql/ConnectNile.mdx
+++ b/src/mdx/get-started/postgresql/ConnectNile.mdx
@@ -1,7 +1,7 @@
 import Callout from '@mdx/Callout.astro';
 import CodeTabs from "@mdx/CodeTabs.astro";
 
-Create a `index.ts` file in the `src/db` directory and initialize the connection:
+Create a `index.ts` file in the `src` directory and initialize the connection:
 
 <CodeTabs items={["node-postgres", "node-postgres with config", "your node-postgres driver"]}>
 ```typescript copy

--- a/src/mdx/get-started/postgresql/ConnectPgLite.mdx
+++ b/src/mdx/get-started/postgresql/ConnectPgLite.mdx
@@ -1,4 +1,4 @@
-Create a `index.ts` file in the `src/db` directory and initialize the connection:
+Create a `index.ts` file in the `src` directory and initialize the connection:
 
 ```typescript copy
 import { drizzle } from 'drizzle-orm/pglite';

--- a/src/mdx/get-started/postgresql/ConnectPostgreSQL.mdx
+++ b/src/mdx/get-started/postgresql/ConnectPostgreSQL.mdx
@@ -1,6 +1,6 @@
 import CodeTabs from "@mdx/CodeTabs.astro";
 
-Create a `index.ts` file in the `src/db` directory and initialize the connection:
+Create a `index.ts` file in the `src` directory and initialize the connection:
 
 <CodeTabs items={["node-postgres", "node-postgres with config", "your node-postgres driver"]}>
 ```typescript copy

--- a/src/mdx/get-started/postgresql/ConnectSupabase.mdx
+++ b/src/mdx/get-started/postgresql/ConnectSupabase.mdx
@@ -1,6 +1,6 @@
 import Callout from '@mdx/Callout.astro';
 
-Create a `index.ts` file in the `src/db` directory and initialize the connection:
+Create a `index.ts` file in the `src` directory and initialize the connection:
 
 ```typescript copy filename="index.ts"
 import { drizzle } from 'drizzle-orm'

--- a/src/mdx/get-started/postgresql/ConnectVercel.mdx
+++ b/src/mdx/get-started/postgresql/ConnectVercel.mdx
@@ -1,4 +1,4 @@
-Create a `index.ts` file in the `src/db` directory and initialize the connection:
+Create a `index.ts` file in the `src` directory and initialize the connection:
 
 ```typescript copy
 import { drizzle } from 'drizzle-orm/vercel-postgres';

--- a/src/mdx/get-started/postgresql/ConnectXata.mdx
+++ b/src/mdx/get-started/postgresql/ConnectXata.mdx
@@ -1,4 +1,4 @@
-Create a `index.ts` file in the `src/db` directory and initialize the connection:
+Create a `index.ts` file in the `src` directory and initialize the connection:
 
 ```typescript copy"
 import { drizzle } from 'drizzle-orm/xata-http';

--- a/src/mdx/get-started/singlestore/ConnectSingleStore.mdx
+++ b/src/mdx/get-started/singlestore/ConnectSingleStore.mdx
@@ -1,7 +1,7 @@
 import Callout from '@mdx/Callout.astro';
 import CodeTabs from "@mdx/CodeTabs.astro";
 
-Create a `index.ts` file in the `src/db` directory and initialize the connection:
+Create a `index.ts` file in the `src` directory and initialize the connection:
 
 <CodeTabs items={['mysql2', 'mysql2 with config', 'your mysql2 driver']}>
 ```typescript copy


### PR DESCRIPTION
This PR fixes inconsistencies in the `index.ts` location across the "Get Started" pages.

In several steps (file structure, seed & query, run `index.ts`), the `index.ts` file is located in the `src` directory. However, the "connect" step incorrectly specifies `src/db` as the directory in which to create index.ts.

This update changes all `src/db` references to `src` in the "connect" step, ensuring consistency with the other steps.