### PR TITLE
Fix type error and remove unused import in Neon docs

### DIFF
--- a/src/content/docs/tutorials/drizzle-on-the-edge/drizzle-with-vercel-edge-functions.mdx
+++ b/src/content/docs/tutorials/drizzle-on-the-edge/drizzle-with-vercel-edge-functions.mdx
@@ -147,7 +147,6 @@ npx drizzle-kit push
 Create a `index.ts` file in the `src/db` directory and set up your database configuration:
 
 ```typescript copy filename="src/db/index.ts"
-import { Pool } from '@neondatabase/serverless';
 import { drizzle } from 'drizzle-orm/neon-serverless';
 
 

--- a/src/mdx/get-started/postgresql/ConnectNeon.mdx
+++ b/src/mdx/get-started/postgresql/ConnectNeon.mdx
@@ -15,7 +15,7 @@ where you specify a driver connection and pass it to the Drizzle instance.
 
 ```typescript
 import { neon } from '@neondatabase/serverless';
-import { drizzle } from 'drizzle-orm/neon-serverless';
+import { drizzle } from 'drizzle-orm/neon-http';
 
 const sql = neon(process.env.DATABASE_URL!);
 const db = drizzle({ client: sql });


### PR DESCRIPTION
This PR removes one unused import and attempts to fix a type error in the Neon docs.

## Type error

On [docs/get-started/neon-new](https://orm.drizzle.team/docs/get-started/neon-new) on [Step 3 - Connect Drizzle ORM to the database](https://orm.drizzle.team/docs/get-started/neon-new#step-3---connect-drizzle-orm-to-the-database).

> If you need a synchronous connection, you can use our additional connection API, where you specify a driver connection and pass it to the Drizzle instance.

### Code

```ts
import { neon } from '@neondatabase/serverless';
import { drizzle } from 'drizzle-orm/neon-serverless';

const sql = neon(process.env.DATABASE_URL!);
const db = drizzle({ client: sql });
```

### Type error for `drizzle({ client: sql })`

```txt
Argument of type '[{ client: NeonQueryFunction<false, false>; }]' is not assignable to parameter of type '[string | NeonClient] | [string | NeonClient, DrizzleConfig<Record<string, never>>] | [DrizzleConfig<Record<string, never>> & (({ ...; } | { ...; }) & { ...; })]'.
  Type '[{ client: NeonQueryFunction<false, false>; }]' is not assignable to type '[string | NeonClient] | [DrizzleConfig<Record<string, never>> & (({ connection: string | PoolConfig; } | { client: NeonClient; }) & { ...; })]'.
    Type '[{ client: NeonQueryFunction<false, false>; }]' is not assignable to type '[string | NeonClient]'.
      Object literal may only specify known properties, and 'client' does not exist in type 'NeonClient'.ts(2345)
```

### Proposed solution

I think this code example is only meant to showcase passing the neon driver to Drizzle? In this case, I think we just need to update `drizzle-orm/neon-serverless` to `drizzle-orm/neon-http` for the default driver.

Not added in this PR, but if this example is meant to showcase the optional ws-based driver (which is brought up earlier on the same page), then I think more changes are needed:

```ts
// Use the Pool or Client constructors, instead of the functions described above, when you need:
// session or interactive transaction support, and/or compatibility with node-postgres
// See https://neon.tech/docs/serverless/serverless-driver#use-the-driver-over-websockets

import { drizzle } from 'drizzle-orm/neon-serverless';
import { Pool } from '@neondatabase/serverless';

const pool = new Pool({ connectionString: process.env.DATABASE_URL });
const db = drizzle(pool);

```ts
// In environments where ws is not built in:
import { Pool, neonConfig } from '@neondatabase/serverless';
import ws from 'ws';

neonConfig.webSocketConstructor = ws;
```

