### PR TITLE
docs: Updated Cloudflare D1 example to include wrangler.json

### DIFF
--- a/src/content/docs/connect-cloudflare-d1.mdx
+++ b/src/content/docs/connect-cloudflare-d1.mdx
@@ -31,19 +31,39 @@ drizzle-orm
 
 #### Step 2 - Initialize the driver and make a query
 
-You would need to have a `wrangler.toml` file for D1 database and will look something like this:
+You would need to have either a `wrangler.json` or a `wrangler.toml` file for D1 database and will look something like this:
+<CodeTabs items={["wrangler.json", "wrangler.toml"]}>
+```json
+{
+    "name": "YOUR_PROJECT_NAME",
+    "main": "src/index.ts",
+    "compatibility_date": "2024-09-26",
+    "compatibility_flags": [
+        "nodejs_compat"
+    ],
+    "d1_databases": [
+        {
+            "binding": "BINDING_NAME",
+            "database_name": "YOUR_DB_NAME",
+            "database_id": "YOUR_DB_ID",
+            "migrations_dir": "drizzle/migrations"
+        }
+    ]
+}
+```
 ```toml
-name = "YOUR PROJECT NAME"
+name = "YOUR_PROJECT_NAME"
 main = "src/index.ts"
 compatibility_date = "2022-11-07"
 node_compat = true
 
 [[ d1_databases ]]
-binding = "DB"
-database_name = "YOUR DB NAME"
-database_id = "YOUR DB ID"
+binding = "BINDING_NAME"
+database_name = "YOUR_DB_NAME"
+database_id = "YOUR_DB_ID"
 migrations_dir = "drizzle/migrations"
 ```
+</CodeTabs>
 
 Make your first D1 query:
 ```typescript copy


### PR DESCRIPTION
Since wrangler now supports both `wrangler.json` and `wrangler.toml` I've updated the Cloudflare D1's docs page to provide an example with `wrangler.json` too.