### PR TITLE
docs: fix generate docs typo

### DIFF
--- a/src/content/docs/drizzle-kit-generate.mdx
+++ b/src/content/docs/drizzle-kit-generate.mdx
@@ -171,8 +171,8 @@ INSERT INTO "users" ("name") VALUES('Dandrew');
 <rem025/>
 
 <Npx>
-drizzle-kit push --name=init
-drizzle-kit push --name=seed_users --custom
+drizzle-kit generate --name=init
+drizzle-kit generate --name=seed_users --custom
 </Npx>
 
 <br/>


### PR DESCRIPTION
Small fix to `generate` command examples that were referencing `push` command instead.