### PR TITLE
fix: typo in generated-columns.mdx

### DIFF
--- a/src/content/docs/generated-columns.mdx
+++ b/src/content/docs/generated-columns.mdx
@@ -51,7 +51,7 @@ Generated columns can be especially useful for:
 
     #### Drizzle side
     In Drizzle you can specify `.generatedAlwaysAs()` function on any column type and add a supported sql query, 
-    that will generate this column data do you
+    that will generate this column data for you.
 
     #### Features 
     This function can accept generated expression in 3 ways:


### PR DESCRIPTION
 Fixed a small typo. "do you" -> "for you." 