### PR TITLE
fix: incorrect dir linked

### DIFF
--- a/src/mdx/get-started/postgresql/ConnectPostgreSQL.mdx
+++ b/src/mdx/get-started/postgresql/ConnectPostgreSQL.mdx
@@ -1,6 +1,6 @@
 import CodeTabs from "@mdx/CodeTabs.astro";
 
-Create a `index.ts` file in the `src/db` directory and initialize the connection:
+Create a `index.ts` file in the `src` directory and initialize the connection:
 
 <CodeTabs items={["node-postgres", "node-postgres with config", "your node-postgres driver"]}>
 ```typescript copy


### PR DESCRIPTION
Their was a mistake in the docs that the index file is made inside the db folder however according to the project structure and references shown below it is in the src directory.

<img src="https://github.com/user-attachments/assets/3d610462-7c12-4af5-90d6-ae92b716adbd" width="250"/>