### PR TITLE
Fix documentation typo related to copy-paste mistake on sql-schema-declaration page 

### DIFF
--- a/src/content/docs/sql-schema-declaration.mdx
+++ b/src/content/docs/sql-schema-declaration.mdx
@@ -92,8 +92,8 @@ You can also group them in any way you like, such as creating groups for user-re
           └ 📜 products.ts
 ```
 
-In the `drizzle.config.ts` file, you need to specify the path to your schema file. With this configuration, Drizzle will 
-read from the `schema.ts` file and use this information during the migration generation process. For more information 
+In the `drizzle.config.ts` file, you need to specify the path to your schema folder. With this configuration, Drizzle will 
+read from the `schema` folder and find all the files recursively and get all the drizzle tables from there. For more information 
 about the `drizzle.config.ts` file and migrations with Drizzle, please check: [link](/docs/drizzle-config-file)
 
 ```ts


### PR DESCRIPTION
Description:
I found an inaccuracy in the documentation that appears to be caused by a copy-paste error. This PR corrects the issue to improve clarity and accuracy