### PR TITLE
Fixed the inconsistent NPX tab on Overview page of Drizzle Studio

### DIFF
--- a/src/pages/drizzle-studio/overview.mdx
+++ b/src/pages/drizzle-studio/overview.mdx
@@ -21,10 +21,10 @@ delete and update everything based on your existing drizzle sql schema. It suppo
 #### Install dependencies
 Make sure to go through our [get started](/docs/get-started) guides first!
 
-<Npx>
+<Npm>
 drizzle-orm
 -D drizzle-kit
-</Npx>
+</Npm>
 
 #### Prepare your database schema
 Check out extended schema declaration **[docs.](/docs/sql-schema-declaration)**
@@ -53,38 +53,19 @@ export default defineConfig({
 });
 ```
 #### Launch Drizzle Studio
-<Tabs items={["npm", "pnpm", "yarn", "bun"]}>
-<Tab>
-```bash copy
-npx drizzle-kit studio
-```
-</Tab>
-<Tab>
-```bash copy
-pnpm drizzle-kit studio
-```
-</Tab>
-<Tab>
-```bash copy
-yarn drizzle-kit studio
-```
-</Tab>
-<Tab>
-```bash copy
-bunx drizzle-kit studio
-```
-</Tab>
-</Tabs>
+<Npx>
+drizzle-kit studio
+</Npx>
 
 You can launch studio with `port` cli flag to customise process port and `verbose` flag for extended SQL statements logging
-```bash
-yarn drizzle-kit studio --port 3000 --verbose
-```
+<Npx>
+drizzle-kit studio --port 3000 --verbose
+</Npx>
 
 By default, Drizzle Studio will be launched on the `https://local.drizzle.studio` host, and studio server will be launched on 127.0.0.1 host but you can specify any host you want
-```bash
-yarn drizzle-kit studio --host 0.0.0.0
-```
+<Npx>
+drizzle-kit studio --host 0.0.0.0
+</Npx>
 </Steps>
 
 


### PR DESCRIPTION
Install dependencies section: switch from `npx` to `npm i` instead.
The rest of the code switch from Tab to **Npx** Component and launching option into **Npx** too instead of only `yarn`.