### PR TITLE
Update installation commands and instructions

### DIFF
--- a/src/mdx/Npx.astro
+++ b/src/mdx/Npx.astro
@@ -1,7 +1,7 @@
 ---
 const items = ["npm", "yarn", "pnpm", "bun"];
 const html = await Astro.slots.render("default");
-const installCommands = ["npx", "yarn", "pnpm", "bun"];
+const installCommands = ["npx", "yarn", "pnpm", "bunx"];
 const installLines = html
   .replaceAll(/<\/?p>/g, "")
   .replaceAll("—", "--")

--- a/src/pages/drizzle-studio/overview.mdx
+++ b/src/pages/drizzle-studio/overview.mdx
@@ -21,10 +21,10 @@ delete and update everything based on your existing drizzle sql schema. It suppo
 #### Install dependencies
 Make sure to go through our [get started](/docs/get-started) guides first!
 
-<Npx>
+<Npm>
 drizzle-orm
 -D drizzle-kit
-</Npx>
+</Npm>
 
 #### Prepare your database schema
 Check out extended schema declaration **[docs.](/docs/sql-schema-declaration)**
@@ -53,28 +53,9 @@ export default defineConfig({
 });
 ```
 #### Launch Drizzle Studio
-<Tabs items={["npm", "pnpm", "yarn", "bun"]}>
-<Tab>
-```bash copy
-npx drizzle-kit studio
-```
-</Tab>
-<Tab>
-```bash copy
-pnpm drizzle-kit studio
-```
-</Tab>
-<Tab>
-```bash copy
-yarn drizzle-kit studio
-```
-</Tab>
-<Tab>
-```bash copy
-bunx drizzle-kit studio
-```
-</Tab>
-</Tabs>
+<Npx>
+drizzle-kit studio drizzle-orm
+</Npx>
 
 You can launch studio with `port` cli flag to customise process port and `verbose` flag for extended SQL statements logging
 ```bash


### PR DESCRIPTION
Replace 'bun' with 'bunx' in installation commands and update the installation instructions in the documentation for clarity.
