### PR TITLE
[SingleStore] Add Vector column/index doc, fix SingleStore imports

### DIFF
--- a/src/content/docs/column-types/singlestore.mdx
+++ b/src/content/docs/column-types/singlestore.mdx
@@ -20,7 +20,7 @@ A signed integer, stored in `0`, `1`, `2`, `3`, `4`, `6`, or `8` bytes depending
 
 <Section>
 ```typescript
-import { int, singlestoreTable } from "drizzle-orm/mysql-core";
+import { int, singlestoreTable } from "drizzle-orm/singlestore-core";
 
 const table = singlestoreTable('table', {
 	int: int()
@@ -38,7 +38,7 @@ CREATE TABLE `table` (
 
 <Section>
 ```typescript
-import { tinyint, singlestoreTable } from "drizzle-orm/mysql-core";
+import { tinyint, singlestoreTable } from "drizzle-orm/singlestore-core";
 
 const table = singlestoreTable('table', {
 	tinyint: tinyint()
@@ -56,7 +56,7 @@ CREATE TABLE `table` (
 
 <Section>
 ```typescript
-import { smallint, singlestoreTable } from "drizzle-orm/mysql-core";
+import { smallint, singlestoreTable } from "drizzle-orm/singlestore-core";
 
 const table = singlestoreTable('table', {
 	smallint: smallint()
@@ -74,7 +74,7 @@ CREATE TABLE `table` (
 
 <Section>
 ```typescript
-import { mediumint, singlestoreTable } from "drizzle-orm/mysql-core";
+import { mediumint, singlestoreTable } from "drizzle-orm/singlestore-core";
 
 const table = singlestoreTable('table', {
 	mediumint: mediumint()
@@ -92,7 +92,7 @@ CREATE TABLE `table` (
 
 <Section>
 ```typescript
-import { bigint, singlestoreTable } from "drizzle-orm/mysql-core";
+import { bigint, singlestoreTable } from "drizzle-orm/singlestore-core";
 
 const table = singlestoreTable('table', {
 	bigint: bigint({ mode: 'number' })
@@ -121,7 +121,7 @@ We've omitted config of `M` in `bigint(M)`, since it indicates the display width
 
 <Section>
 ```typescript
-import { real, singlestoreTable } from "drizzle-orm/mysql-core";
+import { real, singlestoreTable } from "drizzle-orm/singlestore-core";
 
 const table = singlestoreTable('table', {
 	real: real()
@@ -137,7 +137,7 @@ CREATE TABLE `table` (
 
 <Section>
 ```typescript
-import { real, singlestoreTable } from "drizzle-orm/mysql-core";
+import { real, singlestoreTable } from "drizzle-orm/singlestore-core";
 
 const table = singlestoreTable('table', {
 	realPrecision: real({ precision: 1,}),
@@ -157,7 +157,7 @@ CREATE TABLE `table` (
 
 <Section>
 ```typescript
-import { decimal, singlestoreTable } from "drizzle-orm/mysql-core";
+import { decimal, singlestoreTable } from "drizzle-orm/singlestore-core";
 
 const table = singlestoreTable('table', {
 	decimal: decimal()
@@ -173,7 +173,7 @@ CREATE TABLE `table` (
 
 <Section>
 ```typescript
-import { decimal, singlestoreTable } from "drizzle-orm/mysql-core";
+import { decimal, singlestoreTable } from "drizzle-orm/singlestore-core";
 
 const table = singlestoreTable('table', {
 	decimalPrecision: decimal({ precision: 1,}),
@@ -193,7 +193,7 @@ CREATE TABLE `table` (
 
 <Section>
 ```typescript
-import { double, singlestoreTable } from "drizzle-orm/mysql-core";
+import { double, singlestoreTable } from "drizzle-orm/singlestore-core";
 
 const table = singlestoreTable('table', {
 	double: double('double')
@@ -209,7 +209,7 @@ CREATE TABLE `table` (
 
 <Section>
 ```typescript
-import { double, singlestoreTable } from "drizzle-orm/mysql-core";
+import { double, singlestoreTable } from "drizzle-orm/singlestore-core";
 
 const table = singlestoreTable('table', {
 	doublePrecision: double({ precision: 1,}),
@@ -229,7 +229,7 @@ CREATE TABLE `table` (
 
 <Section>
 ```typescript
-import { float, singlestoreTable } from "drizzle-orm/mysql-core";
+import { float, singlestoreTable } from "drizzle-orm/singlestore-core";
 
 const table = singlestoreTable('table', {
 	float: float()
@@ -252,7 +252,7 @@ CREATE TABLE `table` (
 `SERIAL` is an alias for `BIGINT UNSIGNED NOT NULL AUTO_INCREMENT UNIQUE`.
 
 ```typescript
-import { serial, singlestoreTable } from "drizzle-orm/mysql-core";
+import { serial, singlestoreTable } from "drizzle-orm/singlestore-core";
 
 const table = singlestoreTable('table', {
 	serial: serial()
@@ -272,7 +272,7 @@ CREATE TABLE `table` (
 
 <Section>
 ```typescript
-import { binary, singlestoreTable } from "drizzle-orm/mysql-core";
+import { binary, singlestoreTable } from "drizzle-orm/singlestore-core";
 
 const table = singlestoreTable('table', {
 	binary: binary()
@@ -290,7 +290,7 @@ CREATE TABLE `table` (
 
 <Section>
 ```typescript
-import { varbinary, singlestoreTable } from "drizzle-orm/mysql-core";
+import { varbinary, singlestoreTable } from "drizzle-orm/singlestore-core";
 
 const table = singlestoreTable('table', {
 	varbinary: varbinary({ length: 2}),
@@ -310,7 +310,7 @@ CREATE TABLE `table` (
 
 <Section>
 ```typescript
-import { char, singlestoreTable } from "drizzle-orm/mysql-core";
+import { char, singlestoreTable } from "drizzle-orm/singlestore-core";
 
 const table = singlestoreTable('table', {
 	char: char(),
@@ -328,7 +328,7 @@ CREATE TABLE `table` (
 You can define `{ enum: ["value1", "value2"] }` config to infer `insert` and `select` types, it **won't** check runtime values.
 <Section>
 ```typescript
-import { varchar, singlestoreTable } from "drizzle-orm/mysql-core";
+import { varchar, singlestoreTable } from "drizzle-orm/singlestore-core";
 
 const table = singlestoreTable('table', {
 	varchar: varchar({ length: 2 }),
@@ -351,7 +351,7 @@ You can define `{ enum: ["value1", "value2"] }` config to infer `insert` and `se
 
 <Section>
 ```typescript
-import { text, singlestoreTable } from "drizzle-orm/mysql-core";
+import { text, singlestoreTable } from "drizzle-orm/singlestore-core";
 
 const table = singlestoreTable('table', {
 	text: text(),
@@ -374,7 +374,7 @@ CREATE TABLE `table` (
 
 <Section>
 ```typescript
-import { boolean, singlestoreTable } from "drizzle-orm/mysql-core";
+import { boolean, singlestoreTable } from "drizzle-orm/singlestore-core";
 
 const table = singlestoreTable('table', {
 	boolean: boolean(),
@@ -394,7 +394,7 @@ CREATE TABLE `table` (
 
 <Section>
 ```typescript
-import { boolean, singlestoreTable } from "drizzle-orm/mysql-core";
+import { boolean, singlestoreTable } from "drizzle-orm/singlestore-core";
 
 const table = singlestoreTable('table', {
 	date: date(),
@@ -412,7 +412,7 @@ CREATE TABLE `table` (
 
 <Section>
 ```typescript
-import { datetime, singlestoreTable } from "drizzle-orm/mysql-core";
+import { datetime, singlestoreTable } from "drizzle-orm/singlestore-core";
 
 const table = singlestoreTable('table', {
 	datetime: datetime(),
@@ -432,7 +432,7 @@ CREATE TABLE `table` (
 
 <Section>
 ```typescript
-import { time, singlestoreTable } from "drizzle-orm/mysql-core";
+import { time, singlestoreTable } from "drizzle-orm/singlestore-core";
 
 const table = singlestoreTable('table', {
 	time: time(),
@@ -450,7 +450,7 @@ CREATE TABLE `table` (
 
 <Section>
 ```typescript
-import { year, singlestoreTable } from "drizzle-orm/mysql-core";
+import { year, singlestoreTable } from "drizzle-orm/singlestore-core";
 
 const table = singlestoreTable('table', {
 	year: year(),
@@ -468,7 +468,7 @@ CREATE TABLE `table` (
 
 <Section>
 ```typescript
-import { timestamp, singlestoreTable } from "drizzle-orm/mysql-core";
+import { timestamp, singlestoreTable } from "drizzle-orm/singlestore-core";
 
 const table = singlestoreTable('table', {
 	timestamp: timestamp(),
@@ -486,7 +486,7 @@ CREATE TABLE `table` (
 
 <Section>
 ```typescript
-import { timestamp, singlestoreTable } from "drizzle-orm/mysql-core";
+import { timestamp, singlestoreTable } from "drizzle-orm/singlestore-core";
 
 const table = singlestoreTable('table', {
 	timestamp: timestamp().defaultNow(),
@@ -506,7 +506,7 @@ CREATE TABLE `table` (
 
 <Section>
 ```typescript
-import { json, singlestoreTable } from "drizzle-orm/mysql-core";
+import { json, singlestoreTable } from "drizzle-orm/singlestore-core";
 
 const table = singlestoreTable('table', {
 	json: json(),
@@ -540,10 +540,10 @@ json: json().$type<string[]>().default({});
 
 <Section>
 ```typescript
-import { mysqlEnum, singlestoreTable } from "drizzle-orm/mysql-core";
+import { singlestoreEnum, singlestoreTable } from "drizzle-orm/singlestore-core";
 
 const table = singlestoreTable('table', {
-	mysqlEnum: mysqlEnum(['unknown', 'known', 'popular']),
+	singlestoreEnum: singlestoreEnum(['unknown', 'known', 'popular']),
 });
 ```
 
@@ -551,6 +551,62 @@ const table = singlestoreTable('table', {
 CREATE TABLE `table` (
 	`popularity` enum('unknown','known','popular'),
 );
+```
+</Section>
+
+## ---
+
+### vector
+
+<Section>
+```typescript
+import { singlestoreTable, vector } from "drizzle-orm/singlestore-core";
+
+const table = singlestoreTable('table', {
+	embedding: vector("embedding", { dimensions: 10 }),
+});
+```
+
+```sql
+CREATE TABLE `table` (
+	`embedding` vector(10)
+);
+```
+</Section>
+
+You can specify `elementType` in order to change what element type the vector
+consists of. This can be one of `I8`, `I16`, `I32`, `I64`, `F32`, or `F64`
+
+<Section>
+```typescript
+import { singlestoreTable, vector } from "drizzle-orm/singlestore-core";
+
+const table = singlestoreTable('table', {
+	embedding: vector("embedding", { dimensions: 10, elementType: 'I8' }),
+});
+```
+
+```sql
+CREATE TABLE `table` (
+	`embedding` vector(10, 'I8')
+);
+```
+</Section>
+
+###### Helper functions
+
+There are two helper functions useful for vector search queries in SingleStore:
+
+<Section>
+```typescript
+import { dotProduct, euclideanDistance } from 'drizzle-orm/singlestore-core/expressions';
+
+euclideanDistance(table.column, [3, 1, 2]);
+dotProduct(table.column, [3, 1, 2]);
+```
+```sql
+table.column <-> '[3, 1, 2]'
+table.column <*> '[3, 1, 2]`
 ```
 </Section>
 
@@ -578,7 +634,7 @@ const users = singlestoreTable('users', {
 
 <Section>
 ```typescript
-import { int, singlestoreTable } from "drizzle-orm/mysql-core";
+import { int, singlestoreTable } from "drizzle-orm/singlestore-core";
 
 const table = singlestoreTable('table', {
 	int: int().notNull(),
@@ -604,7 +660,7 @@ a string constant, a blob constant, a signed-number, or any constant expression 
 
 <Section>
 ```typescript
-import { int, singlestoreTable } from "drizzle-orm/mysql-core";
+import { int, singlestoreTable } from "drizzle-orm/singlestore-core";
 
 const table = singlestoreTable('table', {
 	int: int().default(3),
@@ -627,7 +683,7 @@ These functions can assist you in utilizing various implementations such as `uui
 </Callout>
 
 ```ts
-import { varchar, singlestoreTable } from "drizzle-orm/mysql-core";
+import { varchar, singlestoreTable } from "drizzle-orm/singlestore-core";
 import { createId } from '@paralleldrive/cuid2';
 
 const table = singlestoreTable('table', {
@@ -648,7 +704,7 @@ when the row is inserted as well, and the returned value will be used as the col
 </Callout>
 
 ```ts
-import { text, singlestoreTable } from "drizzle-orm/mysql-core";
+import { text, singlestoreTable } from "drizzle-orm/singlestore-core";
 
 const table = singlestoreTable('table', {
     alwaysNull: text().$type<string | null>().$onUpdate(() => null),
@@ -659,7 +715,7 @@ const table = singlestoreTable('table', {
 
 <Section>
 ```typescript
-import { int, singlestoreTable } from "drizzle-orm/mysql-core";
+import { int, singlestoreTable } from "drizzle-orm/singlestore-core";
 
 const table = singlestoreTable('table', {
 	int: int().primaryKey(),
@@ -677,7 +733,7 @@ CREATE TABLE `table` (
 
 <Section>
 ```typescript
-import { int, singlestoreTable } from "drizzle-orm/mysql-core";
+import { int, singlestoreTable } from "drizzle-orm/singlestore-core";
 
 const table = singlestoreTable('table', {
 	int: int().autoincrement(),

--- a/src/content/docs/indexes-constraints.mdx
+++ b/src/content/docs/indexes-constraints.mdx
@@ -1118,7 +1118,7 @@ index('name')
   </Tab>
   <Tab>
     <Section>
-    ```typescript copy {9-10}
+    ```typescript copy {8-9}
     import { int, text, index, uniqueIndex, singlestoreTable } from "drizzle-orm/singlestore-core";
 
     export const user = singlestoreTable("user", {
@@ -1137,6 +1137,31 @@ index('name')
 
     CREATE INDEX `name_idx` ON `user` (`name`);
     CREATE UNIQUE INDEX `email_idx` ON `user` (`email`);
+    ```
+    </Section>
+
+    SingleStore also supports indexes on vector columns:
+
+    <Section>
+    ```typescript copy {8-9}
+    import { int, singlestoreTable, vector, vectorIndex } from "drizzle-orm/singlestore-core";
+
+    export const embeddings = singlestoreTable("embeddings", {
+      id: int("id").primaryKey().autoincrement(),
+      embedding: vector("embedding", { dimensions: 10 }).notNull(),
+      embedding2: vector("embedding2", { dimensions: 10 }).notNull(),
+    }, (table) => [
+      vectorIndex("vIdx1").on(table.embedding),
+      vectorIndex("vIdx2", "IVF_PQ").on(table.embedding2).metricType("EUCLIDEAN_DISTANCE").nbits(16),
+    ]);
+    ```
+    ```sql {5-6}
+    CREATE TABLE `embeddings` (
+      ...
+    );
+
+    ALTER TABLE `embeddings` ADD VECTOR INDEX `vIdx1` (`embedding`) INDEX_OPTIONS '{"index_type":"AUTO"}';
+    ALTER TABLE `embeddings` ADD VECTOR INDEX `vIdx2` (`embedding2`) INDEX_OPTIONS '{"index_type":"IVF_PQ","metric_type":"EUCLIDEAN_DISTANCE","nbits":16}';
     ```
     </Section>
   </Tab>


### PR DESCRIPTION
This PR adds documentation for the `vector` column type to the SingleStore column types doc. It also updates all of the imports on the SingleStore doc to import from `drizzle-orm/singlestore-core` rather than `drizzle-orm/mysql-core`.

Also adds doc for `vector` indexes, which would be added in [this PR to drizzle-orm](https://github.com/drizzle-team/drizzle-orm/pull/4218), meaning this PR should not merge/deploy until that PR is merged and a new version of drizzle-orm/kit are released.

If you would like, or would allow, I can also update the [Vector similarity search](https://orm.drizzle.team/docs/guides/vector-similarity-search) guide to have an option for SingleStore instead of just `pgvector`, as it should be just about a 1:1 mapping.