### PR TITLE
fix: add space between "Singlestore" and "drivers"

### DIFF
--- a/src/content/docs/overview.mdx
+++ b/src/content/docs/overview.mdx
@@ -115,7 +115,7 @@ Drizzle ORM is dialect-specific, slim, performant and serverless-ready **by desi
 
 We've spent a lot of time to make sure you have best-in-class SQL dialect support, including Postgres, MySQL, and others.
 
-Drizzle operates natively through industry-standard database drivers. We support all major **[PostgreSQL](/docs/get-started-postgresql)**, **[MySQL](/docs/get-started-mysql)**, **[SQLite](/docs/get-started-sqlite)** or **[SingleStore](/docs/get-started-singlestore)**drivers out there, and we're adding new ones **[really fast](https://twitter.com/DrizzleORM/status/1653082492742647811?s=20)**.  
+Drizzle operates natively through industry-standard database drivers. We support all major **[PostgreSQL](/docs/get-started-postgresql)**, **[MySQL](/docs/get-started-mysql)**, **[SQLite](/docs/get-started-sqlite)** or **[SingleStore](/docs/get-started-singlestore)** drivers out there, and we're adding new ones **[really fast](https://twitter.com/DrizzleORM/status/1653082492742647811?s=20)**.  
 
 
 ## Welcome on board!


### PR DESCRIPTION
This PR adds space between `**Singlestore**` and `drivers` and thus fixes its formatting.

Before:

<img width="907" alt="image" src="https://github.com/user-attachments/assets/1decaa43-90ea-4a15-be8d-06bdb757e182" />

After:

<img width="998" alt="image" src="https://github.com/user-attachments/assets/fe3d6332-3fb2-4d82-a548-eed1df290f92" />
