### PR TITLE
fix: typo in query data section

### DIFF
--- a/src/content/docs/data-querying.mdx
+++ b/src/content/docs/data-querying.mdx
@@ -12,7 +12,7 @@ import Prerequisites from "@mdx/Prerequisites.astro";
   - How to connect to the database - [Connection Fundamentals](/docs/connect-overview)
 </Prerequisites>
 
-Drizzle gives you a few ways for querying you database and it's up to you to decide which one you'll need in your next project.
+Drizzle gives you a few ways for querying your database and it's up to you to decide which one you'll need in your next project.
 It can be either SQL-like syntax or Relational Syntax. Let's check them:
 
 ## Why SQL-like?


### PR DESCRIPTION
This PR fixes the typo I stumbled upon while browsing the documentation.