### PR TITLE
Fix typo in prisma limitations

### DIFF
--- a/src/content/docs/prisma.mdx
+++ b/src/content/docs/prisma.mdx
@@ -102,6 +102,6 @@ const users = await prisma.$drizzle.select().from(User);
 
 ## Limitations
 
-- [Relational queries](/docs/rqb) are not supported due to a [Prisma driver limitation](https://github.com/prisma/prisma/issues/17576). Because of it, Prisma unable to return query results in array format, which is required for relational queries to work.
+- [Relational queries](/docs/rqb) are not supported due to a [Prisma driver limitation](https://github.com/prisma/prisma/issues/17576). Because of it, Prisma is unable to return query results in array format, which is required for relational queries to work.
 - In SQLite, `.values()` (e.g. `await db.select().from(table).values()`) is not supported, because of the same reason as above.
 - [Prepared statements](/docs/perf-queries#prepared-statement) support is limited - `.prepare()` will only build the SQL query on Drizzle side, because there is no Prisma API for prepared queries.


### PR DESCRIPTION
The sentence was missing `is`