### PR TITLE
docs: Fix incorrect directory in "Connect Drizzle ORM to the Database" sections

### DIFF
--- a/src/mdx/get-started/postgresql/ConnectNeon.mdx
+++ b/src/mdx/get-started/postgresql/ConnectNeon.mdx
@@ -2,7 +2,7 @@ import Callout from '@mdx/Callout.astro';
 import CodeTabs from "@mdx/CodeTabs.astro";
 import Section from "@mdx/Section.astro";
 
-Create a `index.ts` file in the `src/db` directory and initialize the connection:
+Create a `index.ts` file in the `src` directory and initialize the connection:
 
 ```typescript
 import { drizzle } from 'drizzle-orm/neon-http';

--- a/src/mdx/get-started/postgresql/ConnectNile.mdx
+++ b/src/mdx/get-started/postgresql/ConnectNile.mdx
@@ -1,7 +1,7 @@
 import Callout from '@mdx/Callout.astro';
 import CodeTabs from "@mdx/CodeTabs.astro";
 
-Create a `index.ts` file in the `src/db` directory and initialize the connection:
+Create a `index.ts` file in the `src` directory and initialize the connection:
 
 <CodeTabs items={["node-postgres", "node-postgres with config", "your node-postgres driver"]}>
 ```typescript copy

--- a/src/mdx/get-started/postgresql/ConnectPgLite.mdx
+++ b/src/mdx/get-started/postgresql/ConnectPgLite.mdx
@@ -1,4 +1,4 @@
-Create a `index.ts` file in the `src/db` directory and initialize the connection:
+Create a `index.ts` file in the `src` directory and initialize the connection:
 
 ```typescript copy
 import { drizzle } from 'drizzle-orm/pglite';

--- a/src/mdx/get-started/postgresql/ConnectPostgreSQL.mdx
+++ b/src/mdx/get-started/postgresql/ConnectPostgreSQL.mdx
@@ -1,6 +1,6 @@
 import CodeTabs from "@mdx/CodeTabs.astro";
 
-Create a `index.ts` file in the `src/db` directory and initialize the connection:
+Create a `index.ts` file in the `src` directory and initialize the connection:
 
 <CodeTabs items={["node-postgres", "node-postgres with config", "your node-postgres driver"]}>
 ```typescript copy

--- a/src/mdx/get-started/postgresql/ConnectSupabase.mdx
+++ b/src/mdx/get-started/postgresql/ConnectSupabase.mdx
@@ -1,6 +1,6 @@
 import Callout from '@mdx/Callout.astro';
 
-Create a `index.ts` file in the `src/db` directory and initialize the connection:
+Create a `index.ts` file in the `src` directory and initialize the connection:
 
 ```typescript copy filename="index.ts"
 import { drizzle } from 'drizzle-orm'

--- a/src/mdx/get-started/postgresql/ConnectVercel.mdx
+++ b/src/mdx/get-started/postgresql/ConnectVercel.mdx
@@ -1,4 +1,4 @@
-Create a `index.ts` file in the `src/db` directory and initialize the connection:
+Create a `index.ts` file in the `src` directory and initialize the connection:
 
 ```typescript copy
 import { drizzle } from 'drizzle-orm/vercel-postgres';

--- a/src/mdx/get-started/postgresql/ConnectXata.mdx
+++ b/src/mdx/get-started/postgresql/ConnectXata.mdx
@@ -1,4 +1,4 @@
-Create a `index.ts` file in the `src/db` directory and initialize the connection:
+Create a `index.ts` file in the `src` directory and initialize the connection:
 
 ```typescript copy"
 import { drizzle } from 'drizzle-orm/xata-http';


### PR DESCRIPTION
### Summary

This PR fixes a small documentation inconsistency found in several "Getting Started" pages:

> _Create a `index.ts` file in the `src/db` directory and initialize the connection_

The code examples and file structure suggest that the correct path should be:

> _Create a `index.ts` file in the `src` directory_

### Affected docs

- Neon
- Nile
- pgLite
- PostgreSQL
- Supabase
- Vercel
- Xata

### Motivation

This change improves clarity and helps prevent confusion for new users setting up Drizzle ORM.

### Related Issue

Closes #524

---

Let me know if anything needs to be updated or if you'd like me to split this into smaller PRs!
