### PR TITLE
Fix typo in aws-data-api import

### DIFF
--- a/src/content/docs/connect-aws-data-api-pg.mdx
+++ b/src/content/docs/connect-aws-data-api-pg.mdx
@@ -22,7 +22,7 @@ drizzle-orm @aws-sdk/client-rds-data
 
 #### Step 2 - Initialize the driver and make a query
 ```typescript copy
-import { drizzle } from 'drizzle-orm/aws-data-api-pg';
+import { drizzle } from 'drizzle-orm/aws-data-api/pg';
 
 // These three properties are required. You can also specify
 // any property from the RDSDataClient type inside the connection object.


### PR DESCRIPTION
The docs have the wrong import for `aws-data-api`, this corrects it.

Note: [the path is correct in other places in this file already](https://github.com/drizzle-team/drizzle-orm-docs/blob/main/src/content/docs/connect-aws-data-api-pg.mdx?plain=1#L41)