### PR TITLE
Fix Drizzle <> Gel title

### DIFF
--- a/src/content/docs/get-started-gel.mdx
+++ b/src/content/docs/get-started-gel.mdx
@@ -8,7 +8,7 @@ import Prerequisites from "@mdx/Prerequisites.astro";
 import CodeTabs from "@mdx/CodeTabs.astro";
 import WhatsNextPostgres from "@mdx/WhatsNextPostgres.astro";
 
-# Drizzle \<\> PostgreSQL
+# Drizzle \<\> Gel
 <Prerequisites>
 - Database [connection basics](/docs/connect-overview) with Drizzle
 - gel-js [basics](https://github.com/geldata/gel-js)


### PR DESCRIPTION
I think this may have been inadvertently kept when copying and pasting the Postgres page? 

<img width="886" alt="Screenshot 2025-03-23 at 21 11 53" src="https://github.com/user-attachments/assets/991dcae4-7e6b-4b53-8e08-4e002fee5ad0" />
