### PR TITLE
fix(docs): correct index.ts file path in PostgreSQL setup guide

### DIFF
--- a/src/mdx/get-started/mysql/ConnectMySQL.mdx
+++ b/src/mdx/get-started/mysql/ConnectMySQL.mdx
@@ -1,7 +1,7 @@
 import Callout from '@mdx/Callout.astro';
 import CodeTabs from "@mdx/CodeTabs.astro";
 
-Create a `index.ts` file in the `src/db` directory and initialize the connection:
+Create a `index.ts` file in the `src/` directory and initialize the connection:
 
 <CodeTabs items={['mysql2', 'mysql2 with config', 'your mysql2 driver']}>
 ```typescript copy

--- a/src/mdx/get-started/mysql/ConnectPlanetScale.mdx
+++ b/src/mdx/get-started/mysql/ConnectPlanetScale.mdx
@@ -1,4 +1,4 @@
-Create a `index.ts` file in the `src/db` directory and initialize the connection:
+Create a `index.ts` file in the `src/` directory and initialize the connection:
 
 ```typescript copy
 import { drizzle } from "drizzle-orm/planetscale-serverless";

--- a/src/mdx/get-started/mysql/ConnectTiDB.mdx
+++ b/src/mdx/get-started/mysql/ConnectTiDB.mdx
@@ -1,4 +1,4 @@
-Create a `index.ts` file in the `src/db` directory and initialize the connection:
+Create a `index.ts` file in the `src/` directory and initialize the connection:
 
 ```typescript copy
 import { drizzle } from 'drizzle-orm/tidb-serverless';

--- a/src/mdx/get-started/postgresql/ConnectNeon.mdx
+++ b/src/mdx/get-started/postgresql/ConnectNeon.mdx
@@ -2,7 +2,7 @@ import Callout from '@mdx/Callout.astro';
 import CodeTabs from "@mdx/CodeTabs.astro";
 import Section from "@mdx/Section.astro";
 
-Create a `index.ts` file in the `src/db` directory and initialize the connection:
+Create a `index.ts` file in the `src/` directory and initialize the connection:
 
 ```typescript
 import { drizzle } from 'drizzle-orm/neon-http';

--- a/src/mdx/get-started/postgresql/ConnectNile.mdx
+++ b/src/mdx/get-started/postgresql/ConnectNile.mdx
@@ -1,7 +1,7 @@
 import Callout from '@mdx/Callout.astro';
 import CodeTabs from "@mdx/CodeTabs.astro";
 
-Create a `index.ts` file in the `src/db` directory and initialize the connection:
+Create a `index.ts` file in the `src/` directory and initialize the connection:
 
 <CodeTabs items={["node-postgres", "node-postgres with config", "your node-postgres driver"]}>
 ```typescript copy

--- a/src/mdx/get-started/postgresql/ConnectPgLite.mdx
+++ b/src/mdx/get-started/postgresql/ConnectPgLite.mdx
@@ -1,4 +1,4 @@
-Create a `index.ts` file in the `src/db` directory and initialize the connection:
+Create a `index.ts` file in the `src/` directory and initialize the connection:
 
 ```typescript copy
 import { drizzle } from 'drizzle-orm/pglite';

--- a/src/mdx/get-started/postgresql/ConnectPostgreSQL.mdx
+++ b/src/mdx/get-started/postgresql/ConnectPostgreSQL.mdx
@@ -1,6 +1,6 @@
 import CodeTabs from "@mdx/CodeTabs.astro";
 
-Create a `index.ts` file in the `src/db` directory and initialize the connection:
+Create a `index.ts` file in the `src/` directory and initialize the connection:
 
 <CodeTabs items={["node-postgres", "node-postgres with config", "your node-postgres driver"]}>
 ```typescript copy

--- a/src/mdx/get-started/postgresql/ConnectSupabase.mdx
+++ b/src/mdx/get-started/postgresql/ConnectSupabase.mdx
@@ -1,6 +1,6 @@
 import Callout from '@mdx/Callout.astro';
 
-Create a `index.ts` file in the `src/db` directory and initialize the connection:
+Create a `index.ts` file in the `src/` directory and initialize the connection:
 
 ```typescript copy filename="index.ts"
 import { drizzle } from 'drizzle-orm'

--- a/src/mdx/get-started/postgresql/ConnectVercel.mdx
+++ b/src/mdx/get-started/postgresql/ConnectVercel.mdx
@@ -1,4 +1,4 @@
-Create a `index.ts` file in the `src/db` directory and initialize the connection:
+Create a `index.ts` file in the `src/` directory and initialize the connection:
 
 ```typescript copy
 import { drizzle } from 'drizzle-orm/vercel-postgres';

--- a/src/mdx/get-started/postgresql/ConnectXata.mdx
+++ b/src/mdx/get-started/postgresql/ConnectXata.mdx
@@ -1,4 +1,4 @@
-Create a `index.ts` file in the `src/db` directory and initialize the connection:
+Create a `index.ts` file in the `src/` directory and initialize the connection:
 
 ```typescript copy"
 import { drizzle } from 'drizzle-orm/xata-http';

--- a/src/mdx/get-started/singlestore/ConnectSingleStore.mdx
+++ b/src/mdx/get-started/singlestore/ConnectSingleStore.mdx
@@ -1,7 +1,7 @@
 import Callout from '@mdx/Callout.astro';
 import CodeTabs from "@mdx/CodeTabs.astro";
 
-Create a `index.ts` file in the `src/db` directory and initialize the connection:
+Create a `index.ts` file in the `src/` directory and initialize the connection:
 
 <CodeTabs items={['mysql2', 'mysql2 with config', 'your mysql2 driver']}>
 ```typescript copy


### PR DESCRIPTION
This PR resolves [#535](https://github.com/drizzle-team/drizzle-orm-docs/issues/535) by correcting the directory path for the index.ts file in the PostgreSQL setup guide and similar guides. The original instructions incorrectly placed index.ts inside src/db, whereas the file structure consistently shows it should be in src/.
What’s Changed

Updated the path instructions in multiple files under src/mdx/get-started/ to reflect the correct location for creating index.ts.
Affected Files

    MySQL: ConnectMySQL.mdx, ConnectPlanetScale.mdx, ConnectTiDB.mdx

    PostgreSQL: ConnectPostgreSQL.mdx, ConnectNeon.mdx, ConnectNile.mdx, ConnectPgLite.mdx, ConnectSupabase.mdx, ConnectVercel.mdx, ConnectXata.mdx

    SingleStore: ConnectSingleStore.mdx