### PR TITLE
fix: Add warning for mysql2 client configuration for bigint

### DIFF
--- a/src/content/docs/column-types/mysql.mdx
+++ b/src/content/docs/column-types/mysql.mdx
@@ -115,6 +115,20 @@ CREATE TABLE `table` (
 
 We've omitted config of `M` in `bigint(M)`, since it indicates the display width of the numeric type 
 
+<Callout type="warning">
+Using an external mysql2 client, ensure that `supportBigNumbers` and `bigNumberStrings` are enabled.
+Without enabling these options may result in data loss or unexpected errors due to inaccurate handling of large numbers.
+
+```ts copy
+const connection = mysql.createPool({
+  ...
+  supportBigNumbers: true,
+  bigNumberStrings: true,
+});
+export const db = drizzle(connection);
+```
+</Callout>
+
 ## ---
 
 ### real


### PR DESCRIPTION
### About

I would like to add a note about node-mysql2 settings for bigint columns.
There are some reasons.

#### while passing only the DSN automatically enables supportBigNumbers, it would be nice to provide care for cases where it is defined by the user

https://github.com/drizzle-team/drizzle-orm/blob/6ab1bbea566f3e2e048c6980038696e03d8e780a/drizzle-orm/src/mysql2/driver.ts#L151-L156

#### mysql-bigint's mapFromDriverValue expects a string

https://github.com/drizzle-team/drizzle-orm/blob/2677718/drizzle-orm/src/mysql-core/columns/bigint.ts#L95-L97


#### Related issues

https://github.com/drizzle-team/drizzle-orm/issues/4119

### Changes

#### before

https://orm.drizzle.team/docs/column-types/mysql#bigint

#### after

http://localhost:4321/docs/column-types/mysql#bigint

![CleanShot 2025-04-06 at 15 25 08@2x](https://github.com/user-attachments/assets/067c76cf-dc63-4110-951b-ee6d7aaf3706)

