### PR TITLE
Fix missing closing brackets and semicolons in docs

### DIFF
--- a/src/content/docs/drizzle-config-file.mdx
+++ b/src/content/docs/drizzle-config-file.mdx
@@ -247,7 +247,7 @@ export default defineConfig({
   dbCredentials: {
     url: "postgres://user:password@host:port/db",
   }
-})
+});
 ```
 ```ts
 import { defineConfig } from 'drizzle-kit'
@@ -263,7 +263,7 @@ export default defineConfig({
     database: "dbname",
     ssl: true, // can be boolean | "require" | "allow" | "prefer" | "verify-full" | options from node:tls
   }
-})
+});
 ```
 </Section>
 <Section>
@@ -275,7 +275,7 @@ export default defineConfig({
   dbCredentials: {
     url: "postgres://user:password@host:port/db",
   }
-})
+});
 ```
 ```ts
 import { defineConfig } from 'drizzle-kit'
@@ -291,7 +291,7 @@ export default defineConfig({
     database: "dbname",
     ssl: "...", // can be: string | SslOptions (ssl options from mysql2 package)
   }
-})
+});
 ```
 </Section>
 ```ts
@@ -306,7 +306,7 @@ export default defineConfig({
     // or
     url: "file:sqlite.db" // file: prefix is required by libsql
   }
-})
+});
 ```
 ```ts
 import { defineConfig } from 'drizzle-kit'
@@ -323,7 +323,7 @@ export default defineConfig({
     // or
     url: "file:sqlite.db", // file: prefix is required by libsql
   }
-})
+});
 ```
 ```ts
 import { defineConfig } from 'drizzle-kit'
@@ -336,7 +336,7 @@ export default defineConfig({
     databaseId: "",
     token: "",
   }
-})
+});
 ```
 ```ts
 import { defineConfig } from 'drizzle-kit'
@@ -360,7 +360,7 @@ export default defineConfig({
   dbCredentials: {
     url: "./database/", // database folder path
   }
-})
+});
 ```
 </CodeTabs>
 

--- a/src/mdx/DriversExamples.mdx
+++ b/src/mdx/DriversExamples.mdx
@@ -13,7 +13,7 @@ export default defineConfig({
     resourceArn: "resourceArn",
     secretArn: "secretArn",
   },
-};
+});
 ```
 ```ts {6}
 import { defineConfig } from "drizzle-kit";
@@ -29,7 +29,7 @@ export default defineConfig({
     // or database folder
     url: "./database/"
   },
-};
+});
 ```
 ```ts {6}
 import { defineConfig } from "drizzle-kit";
@@ -43,6 +43,6 @@ export default defineConfig({
     databaseId: "databaseId",
     token: "token",
   },
-};
+});
 ```
 </CodeTabs>


### PR DESCRIPTION
This PR fixes minor syntax issues in the MDX documentation file, including missing closing brackets and semicolons.