### PR TITLE
docs: use alias instead of aliasedTable for self-joins

### DIFF
--- a/src/content/docs/joins.mdx
+++ b/src/content/docs/joins.mdx
@@ -204,7 +204,7 @@ Lets say you need to fetch users with their parents:
 ```typescript copy
 import { user } from "./schema";
 
-const parent = aliasedTable(user, "parent")
+const parent = alias(user, "parent");
 const result = db
   .select()
   .from(user)


### PR DESCRIPTION
**docs: Use `alias` instead of `aliasedTable` for self-joins**

This PR corrects the documentation for table aliases and self-joins in `src/content/docs/joins.mdx`.

The previous example incorrectly used `aliasedTable`, which is intended for the Relational Query Builder (RQB) API, leading to confusion and potential type errors (as reported in [#2989](https://github.com/drizzle-team/drizzle-orm/issues/2989)).

This change replaces `aliasedTable` with the correct `alias` function for standard query building, aligning the documentation with the intended usage and resolving the issue reported.