### PR TITLE
docs(drizzle-config-file): schemaFilter for drizzle-kit generate

### DIFF
--- a/src/content/docs/drizzle-config-file.mdx
+++ b/src/content/docs/drizzle-config-file.mdx
@@ -504,7 +504,7 @@ You can configure list of tables, schemas and extensions via `tablesFilters`, `s
 | :------------ | :-----------------   |
 | type          | `string[]` |
 | default       | `["public"]`                    |
-| commands      | `generate` `push` `pull`   |
+| commands      | `push` `pull`   |
 
 <rem025/>
 


### PR DESCRIPTION
The `generate` command does not care about the `schemaFilter` configuration.

See https://github.com/drizzle-team/drizzle-orm/issues/3183#issuecomment-2546315198