### PR TITLE
docs: add missing d1-http driver

### DIFF
--- a/src/content/docs/get-started/d1-new.mdx
+++ b/src/content/docs/get-started/d1-new.mdx
@@ -82,7 +82,7 @@ export default defineConfig({
   out: './drizzle',
   schema: './src/db/schema.ts',
   dialect: 'sqlite',
-  driver: '',
+  driver: 'd1-http',
   dbCredentials: {
     accountId: process.env.CLOUDFLARE_ACCOUNT_ID!,
     databaseId: process.env.CLOUDFLARE_DATABASE_ID!,


### PR DESCRIPTION
When following the written guide (https://orm.drizzle.team/docs/get-started/d1-new) the drizzle config's `driver` property is empty, which generates a TypeScript error. I added `d1-http` to make sure people can follow the docs without getting errors.