### PR TITLE
fix(docs) fix typo in example in drizzle-config-file.mdx

### DIFF
--- a/src/content/docs/drizzle-config-file.mdx
+++ b/src/content/docs/drizzle-config-file.mdx
@@ -573,7 +573,7 @@ By default, `drizzle-kit` won't manage roles for you, so you will need to enable
 ```ts
 export default defineConfig({
   dialect: "postgresql",
-  extensionsFilters: entities: {
+  entities: {
     roles: true
   }
 });


### PR DESCRIPTION
- Remove `extensionsFilters: ` from the start of the line in the entities example code block.