### PR TITLE
Remove extra whitespace character from imports

### DIFF
--- a/src/content/docs/connect-overview.mdx
+++ b/src/content/docs/connect-overview.mdx
@@ -93,12 +93,12 @@ import { drizzle } from "drizzle-orm/vercel-postgres";
 const db = drizzle();
 ```
 ```ts
-import { drizzle  } from "drizzle-orm/planetscale";
+import { drizzle } from "drizzle-orm/planetscale";
 
 const db = drizzle(process.env.DATABASE_URL);
 ```
 ```ts
-import { drizzle  } from "drizzle-orm/d1";
+import { drizzle } from "drizzle-orm/d1";
 
 const db = drizzle({ connection: env.DB });
 ```


### PR DESCRIPTION
This commit removes extra whitespace in the import statements for `drizzle-orm/planetscale` and `drizzle-org/d1` in the Database connection page on the documentation website (https://orm.drizzle.team/docs/connect-overview).

#### Planetscale (incorrect)
![CleanShot 2025-05-11 at 14 42 45@2x](https://github.com/user-attachments/assets/cdbcd280-e723-4a2f-b303-c3139d33db0d)

#### Neon (correct)
![CleanShot 2025-05-11 at 14 42 42@2x](https://github.com/user-attachments/assets/f82a2c80-487b-4cd6-acb8-842d6d715781)

