### PR TITLE
Include helpful information about relations

### DIFF
--- a/src/content/docs/relations.mdx
+++ b/src/content/docs/relations.mdx
@@ -113,6 +113,9 @@ const user = await queryUserWithProfileInfo();
 //____^? type { id: number, profileInfo: { ... } | null  }
 ```
 
+> [!TIP]
+> You may only have one relations export per table, even if separated between different files
+
 ### One-to-many
 Drizzle ORM provides you an API to define `one-to-many` relations between tables with `relations` operator. 
 


### PR DESCRIPTION
If you export multiple relations for one table, it breaks. I added a quick blurb to notify people about this pitfall. Not sure if there is a better syntax.

(P.S. meant to give the commit a better name but forgot before I clicked commit)