### PR TITLE
Fix typo in LibsqlTable.mdx

### DIFF
--- a/src/mdx/LibsqlTable.mdx
+++ b/src/mdx/LibsqlTable.mdx
@@ -4,6 +4,6 @@
 | `@libsql/client/node`    | `node` compatible module, supports `:memory:`, `file`, `wss`, `http` and `turso` connection protocols                                     |
 | `@libsql/client/web`     | module for fullstack web frameworks like `next`, `nuxt`, `astro`, etc.                                                                    |
 | `@libsql/client/http`    | module for `http` and `https` connection protocols                                                                                        |
-| `@libsql/client/ws`      | module for `ws` and `wss` conneciton protocols                                                                                            |
+| `@libsql/client/ws`      | module for `ws` and `wss` connection protocols                                                                                            
 | `@libsql/client/sqlite3` | module for `:memory:` and `file` connection protocols                                                                                     |
 | `@libsql/client-wasm`    | Separate experimental package for WASM                                                                                                    |

--- a/src/mdx/LibsqlTable.mdx
+++ b/src/mdx/LibsqlTable.mdx
@@ -1,9 +1,9 @@
 |                          |                                                                                                                                           |
 | :----------------------- | :---------------------------------------------------------------------------------------------------------------------------------------- |
 | `@libsql/client`         | defaults to `node` import, automatically changes to `web` if `target` or `platform` is set for bundler, e.g. `esbuild --platform=browser` |
-| `@libsql/client/node`    | `node` compatible module, supports `:memory:`, `file`, `wss`, `http` and `turso` conneciton protocols                                     |
+| `@libsql/client/node`    | `node` compatible module, supports `:memory:`, `file`, `wss`, `http` and `turso` connection protocols                                     |
 | `@libsql/client/web`     | module for fullstack web frameworks like `next`, `nuxt`, `astro`, etc.                                                                    |
 | `@libsql/client/http`    | module for `http` and `https` connection protocols                                                                                        |
 | `@libsql/client/ws`      | module for `ws` and `wss` conneciton protocols                                                                                            |
-| `@libsql/client/sqlite3` | module for `:memory:` and `file` conneciton protocols                                                                                     |
+| `@libsql/client/sqlite3` | module for `:memory:` and `file` connection protocols                                                                                     |
 | `@libsql/client-wasm`    | Separate experimental package for WASM                                                                                                    |


### PR DESCRIPTION
changed `conneciton` to `connection`