### PR TITLE
fix(expo-sqlite): update outdated expo-sqlite imports

### DIFF
--- a/src/content/docs/connect-expo-sqlite.mdx
+++ b/src/content/docs/connect-expo-sqlite.mdx
@@ -21,7 +21,7 @@ drizzle-orm expo-sqlite@next
 
 ```ts
 import { drizzle } from "drizzle-orm/expo-sqlite";
-import { openDatabaseSync } from "expo-sqlite/next";
+import { openDatabaseSync } from "expo-sqlite";
 
 const expo = openDatabaseSync("db.db");
 const db = drizzle(expo);
@@ -32,7 +32,7 @@ await db.select().from(users);
 With `useLiveQuery` hook you can make any Drizzle query reactive:
 ```ts
 import { useLiveQuery, drizzle } from 'drizzle-orm/expo-sqlite';
-import { openDatabaseSync } from 'expo-sqlite/next';
+import { openDatabaseSync } from 'expo-sqlite';
 import { Text } from 'react-native';
 import * as schema from './schema';
 
@@ -108,7 +108,7 @@ You can run migrations on application startup using our custom `useMigrations` m
 
 ```ts filename="App.tsx"
 import { drizzle } from "drizzle-orm/expo-sqlite";
-import { openDatabaseSync } from "expo-sqlite/next";
+import { openDatabaseSync } from "expo-sqlite";
 import { useMigrations } from 'drizzle-orm/expo-sqlite/migrator';
 import migrations from './drizzle/migrations';
 

--- a/src/content/docs/connect-overview.mdx
+++ b/src/content/docs/connect-overview.mdx
@@ -114,7 +114,7 @@ const db = drizzle("./sqlite.db");
 ```
 ```ts
 import { drizzle } from "drizzle-orm/expo-sqlite";
-import { openDatabaseSync } from "expo-sqlite/next";
+import { openDatabaseSync } from "expo-sqlite";
 
 const expo = openDatabaseSync("db.db");
 const db = drizzle(expo);

--- a/src/content/docs/latest-releases/drizzle-orm-v0292.mdx
+++ b/src/content/docs/latest-releases/drizzle-orm-v0292.mdx
@@ -38,7 +38,7 @@ Then, you can use it like this:
 
 ```ts copy {4,6}
 import { drizzle } from "drizzle-orm/expo-sqlite";
-import { openDatabaseSync } from "expo-sqlite/next";
+import { openDatabaseSync } from "expo-sqlite";
 
 const expoDb = openDatabaseSync("db.db");
 
@@ -110,7 +110,7 @@ Then you need to import `migrations.js` file in your `App.tsx` file from `./driz
 
 ```ts copy {4,11}
 import { drizzle } from "drizzle-orm/expo-sqlite";
-import { openDatabaseSync } from "expo-sqlite/next";
+import { openDatabaseSync } from "expo-sqlite";
 import { useMigrations } from 'drizzle-orm/expo-sqlite/migrator';
 import migrations from './drizzle/migrations';
 

--- a/src/content/docs/latest-releases/drizzle-orm-v0311.mdx
+++ b/src/content/docs/latest-releases/drizzle-orm-v0311.mdx
@@ -15,7 +15,7 @@ We've implemented a native `useLiveQuery` React Hook which observes necessary da
 
 ```tsx
 import { useLiveQuery, drizzle } from 'drizzle-orm/expo-sqlite';
-import { openDatabaseSync } from 'expo-sqlite/next';
+import { openDatabaseSync } from 'expo-sqlite';
 import { users } from './schema';
 import { Text } from 'react-native';
 


### PR DESCRIPTION
The use of expo-sqlite/next has been outdated for months. By default, expo has imported openDatabaseSync since SDK version 51.

We're already on version 53 in the expo, and some updating is needed.

https://docs.expo.dev/versions/v51.0.0/sdk/sqlite/#sqliteopendatabasesyncdatabasename-options