### PR TITLE
docs: fix typo in `dbCredentials.url` to use correct protocol for MySQL

### DIFF
--- a/src/content/docs/drizzle-config-file.mdx
+++ b/src/content/docs/drizzle-config-file.mdx
@@ -273,7 +273,7 @@ import { defineConfig } from 'drizzle-kit'
 export default defineConfig({
   dialect: "mysql",
   dbCredentials: {
-    url: "postgres://user:password@host:port/db",
+    url: "mysql://user:password@host:port/db",
   }
 });
 ```


### PR DESCRIPTION
# Description

Fix protocol of `dbCredentials.url` in drizzle-config-file page.

For dialect `"mysql"`, the protocol should be `mysql://` instead of `postgres://`.

# Screenshots

| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/1c9df03b-35a9-488a-a8f1-9b02c6bd4e8e) | ![image](https://github.com/user-attachments/assets/8ba88548-8bbb-411c-94ff-dbe53dc006a0) |