### PR TITLE
fix: adjust scroll margin for anchor links when dialect tabs are present

### DIFF
--- a/src/ui/DocsLayout.astro
+++ b/src/ui/DocsLayout.astro
@@ -547,6 +547,23 @@ const pageHasDialects = Object.keys(dialects).includes(
         margin: 0 !important;
         padding: 0 !important;
       }
+
+      .page--with-dialect-tabs :target {
+        scroll-margin-block: 4rem;
+      }
     </style>
+    <script is:inline>
+      function toggleTargetScrollMargin() {
+        const hasDialectTabs = document.querySelector(".dialect-tabs__container")
+        if (hasDialectTabs) {
+          document.documentElement.classList.add('page--with-dialect-tabs');
+        } else {
+          document.documentElement.classList.remove('page--with-dialect-tabs');
+        }
+      }
+
+      document.addEventListener("astro:page-load", toggleTargetScrollMargin);
+      document.addEventListener("astro:after-swap", toggleTargetScrollMargin);
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Problem
When a `DialectTab` is present on a page, clicking anchor links in the side navigation causes a confusing user experience because the `DialectTab` covers the target content.

**Before:**
![before](https://github.com/user-attachments/assets/e59074db-dd2a-45e9-80ba-ba71779b2e73)

## Solution
This PR adds `scroll-margin-block: 4rem` to `:target` elements when dialect tabs are detected on the page.

**After:**
![after](https://github.com/user-attachments/assets/b7146e88-8066-4315-8748-d5e863e728f7)