### PR TITLE
[docs] add missing field in the schema

### DIFF
--- a/src/content/docs/rqb.mdx
+++ b/src/content/docs/rqb.mdx
@@ -162,6 +162,7 @@ await db.query.users.findMany(...);
 	export const users = pgTable('users', {
 		id: serial('id').primaryKey(),
 		name: text('name').notNull(),
+		verified: text('verified').notNull(),
 		invitedBy: integer('invited_by').references((): AnyPgColumn => users.id),
 	});
 


### PR DESCRIPTION
The schema is missing the field `verified` even tho later in the docs says at: https://orm.drizzle.team/docs/rqb#find-many

```
// result type
const result: {
	id: number;
	name: string;
	verified: boolean;
	invitedBy: number | null;
}[];
```