### PR TITLE
Fix AWS Lambda typo

### DIFF
--- a/src/content/docs/perf-serverless.mdx
+++ b/src/content/docs/perf-serverless.mdx
@@ -1,6 +1,6 @@
 # Drizzle Serverless performance
 
-You can get immense benefits with `serverless functions` like AWS Lamba or Vercel Server Functions (they're AWS Lamba based), 
+You can get immense benefits with `serverless functions` like AWS Lambda or Vercel Server Functions (they're AWS Lambda based), 
 since they can live up to 15mins and reuse both database connections and prepared statements.
 
 On the other, hand `edge functions` tend to clean up straight after they're invoked which leads to little to no performance benefits.


### PR DESCRIPTION
This pull request includes a small typo fix in the `src/content/docs/perf-serverless.mdx` file, correcting "AWS Lamba" to "AWS Lambda".