### PR TITLE
Fix the Keyv cache example to have correct TTL

### DIFF
--- a/src/content/docs/cache.mdx
+++ b/src/content/docs/cache.mdx
@@ -243,13 +243,7 @@ export class TestGlobalCache extends Cache {
     tables: string[],
     config?: CacheConfig,
   ): Promise<void> {
-    // The Keyv TTL is in milliseconds
-    // - config.ex is in seconds
-    // - config.px is in milliseconds
-    // You should implement other CacheConfig fields if you need them
-    const ttl = config
-      ? (config.px ?? (config.ex ? config.ex * 1000 : this.globalTtl))
-      : this.globalTtl;
+    const ttl = config?.px ?? (config?.ex ? config.ex * 1000 : this.globalTtl);
 
     await this.kv.set(key, response, ttl);
 

--- a/src/content/docs/cache.mdx
+++ b/src/content/docs/cache.mdx
@@ -243,7 +243,16 @@ export class TestGlobalCache extends Cache {
     tables: string[],
     config?: CacheConfig,
   ): Promise<void> {
-    await this.kv.set(key, response, config ? config.ex : this.globalTtl);
+    // The Keyv TTL is in milliseconds
+    // - config.ex is in seconds
+    // - config.px is in milliseconds
+    // You should implement other CacheConfig fields if you need them
+    const ttl = config
+      ? (config.px ?? (config.ex ? config.ex * 1000 : this.globalTtl))
+      : this.globalTtl;
+
+    await this.kv.set(key, response, ttl);
+
     for (const table of tables) {
       const keys = this.usedTablesPerKey[table];
       if (keys === undefined) {


### PR DESCRIPTION
`CacheConfig.ex` is documented to be in seconds while the example implementation directly used it as an argument in the `put` method from Keyv (which accepts ttl in milliseconds)

https://github.com/jaredwray/keyv/tree/main/packages/keyv#setkey-value-ttl