### PR TITLE
docs: Update migrations.mdx

### DIFF
--- a/src/content/docs/migrations.mdx
+++ b/src/content/docs/migrations.mdx
@@ -76,7 +76,7 @@ import * as p from "drizzle-orm/pg-core";
 export const users = p.pgTable("users", {
   id: p.serial().primaryKey(),
   name: p.text(),
-  email: p.text().unique(), 
+  email: p.text().unique(),
 });
 ```
 </Section>
@@ -106,7 +106,7 @@ export const users = p.pgTable("users", {
   id: p.serial().primaryKey(),
   name: p.text(),
   email: p.text().unique(), // <--- added column
-};
+});
 ```
 ```
 Add column to `users` table                                                                          
@@ -151,8 +151,8 @@ import * as p from "drizzle-orm/pg-core";
 export const users = p.pgTable("users", {
   id: p.serial().primaryKey(),
   name: p.text(),
-  email: p.text().unique(), 
-};
+  email: p.text().unique(),
+});
 ```
 ```                                  
 ┌────────────────────────┐                  
@@ -219,8 +219,8 @@ import * as p from "drizzle-orm/pg-core";
 export const users = p.pgTable("users", {
   id: p.serial().primaryKey(),
   name: p.text(),
-  email: p.text().unique(), 
-};
+  email: p.text().unique(),
+});
 ```
 ```                                  
 ┌────────────────────────┐                  
@@ -294,8 +294,8 @@ import * as p from "drizzle-orm/pg-core";
 export const users = p.pgTable("users", {
   id: p.serial().primaryKey(),
   name: p.text(),
-  email: p.text().unique(), 
-};
+  email: p.text().unique(),
+});
 ```
 ```                                  
 ┌────────────────────────┐                  
@@ -369,8 +369,8 @@ import * as p from "drizzle-orm/pg-core";
 export const users = p.pgTable("users", {
   id: p.serial().primaryKey(),
   name: p.text(),
-  email: p.text().unique(), 
-};
+  email: p.text().unique(),
+});
 ```
 ```                                  
 ┌────────────────────────┐                  

--- a/src/content/docs/migrations.mdx
+++ b/src/content/docs/migrations.mdx
@@ -77,7 +77,7 @@ export const users = p.pgTable("users", {
   id: p.serial().primaryKey(),
   name: p.text(),
   email: p.text().unique(), 
-};
+});
 ```
 </Section>
 </Callout>


### PR DESCRIPTION
The schema demo code in [Option 2](https://orm.drizzle.team/docs/migrations#how-can-drizzle-help) misses the right bracket
<img width="2560" height="1415" alt="image" src="https://github.com/user-attachments/assets/df52c665-66f0-4927-9fe4-f89b9d877405" />
