### PR TITLE
docs: add missing semicolon in drizzle-config-file example

### DIFF
--- a/src/content/docs/drizzle-config-file.mdx
+++ b/src/content/docs/drizzle-config-file.mdx
@@ -91,7 +91,7 @@ export default defineConfig({
       exclude: [],
       include: []
     }
-  }
+  },
 
   breakpoints: true,
   strict: true,


### PR DESCRIPTION
Missing semi-colon in code snippet of drizzle config file example
Page Url: https://orm.drizzle.team/docs/drizzle-config-file

<img width="1849" height="989" alt="image" src="https://github.com/user-attachments/assets/2a16a7ec-950a-491c-9a4d-d14e11436ac3" />
