### PR TITLE
fix: Prevent unexpected line break in navbar

### DIFF
--- a/src/ui/components/LandingNavbar.astro
+++ b/src/ui/components/LandingNavbar.astro
@@ -42,6 +42,7 @@
     transition: all .2s ease;
     border-radius: 20px;
     line-height: normal;
+    white-space: nowrap;
   }
 
   html.dark .landing-navbar__wrap_button:hover {


### PR DESCRIPTION
**Before:** 
<img width="428" height="63" alt="image" src="https://github.com/user-attachments/assets/d0b2bfe7-94b8-4e66-a362-02fc2d559afb" />

**After:** 
<img width="439" height="47" alt="image" src="https://github.com/user-attachments/assets/60635ed9-5a27-420a-a9b6-6a3ec1fe1d10" />