### PR TITLE
fix: use `(unixepoch('subsecond') * 1000)` to get proper precision of timestamp

### DIFF
--- a/src/content/docs/guides/timestamp-default-value.mdx
+++ b/src/content/docs/guides/timestamp-default-value.mdx
@@ -267,7 +267,7 @@ export const users = sqliteTable('users', {
     .default(sql`(unixepoch())`),
   timestamp2: integer('timestamp2', { mode: 'timestamp_ms' })
     .notNull()
-    .default(sql`(unixepoch() * 1000)`),
+    .default(sql`(unixepoch('subsecond') * 1000)`),
   timestamp3: integer('timestamp3', { mode: 'number' })
     .notNull()
     .default(sql`(unixepoch())`),
@@ -278,7 +278,7 @@ export const users = sqliteTable('users', {
 CREATE TABLE `users` (
 	`id` integer PRIMARY KEY NOT NULL,
 	`timestamp1` integer DEFAULT (unixepoch()) NOT NULL,
-	`timestamp2` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	`timestamp2` integer DEFAULT (unixepoch('subsecond') * 1000) NOT NULL,
 	`timestamp3` integer DEFAULT (unixepoch()) NOT NULL
 );
 ```
@@ -293,7 +293,7 @@ The difference is that `timestamp` handles seconds, while `timestamp_ms` handles
 +------------+------------+---------------+------------+
 | id         | timestamp1 | timestamp2    | timestamp3 |
 +------------+------------+---------------+------------+
-| 1          | 1712835640 | 1712835640000 | 1712835640 |
+| 1          | 1712835640 | 1712835640469 | 1712835640 |
 +------------+------------+---------------+------------+
 ```
 
@@ -303,7 +303,7 @@ The difference is that `timestamp` handles seconds, while `timestamp_ms` handles
   {
     id: 1,
     timestamp1: 2024-04-11T11:40:40.000Z, // Date object
-    timestamp2: 2024-04-11T11:40:40.000Z, // Date object
+    timestamp2: 2024-04-11T11:40:40.469Z, // Date object
     timestamp3: 1712835640 // number
   }
 ]


### PR DESCRIPTION
close https://github.com/drizzle-team/drizzle-orm/issues/2810