### PR TITLE
docs: Update noen-cf-example link to the correct one and remove the same doc page reference link

### DIFF
--- a/src/content/docs/connect-neon.mdx
+++ b/src/content/docs/connect-neon.mdx
@@ -25,8 +25,8 @@ Querying over HTTP is faster for single, non-interactive transactions.
 If you need session or interactive transaction support, or a fully compatible drop-in replacement for the `pg` driver, you can use the WebSocket-based `neon-serverless` driver.  
 You can connect to a Neon database directly using [Postgres](/docs/get-started/postgresql-new)
   
-For an example of using Drizzle ORM with the Neon Serverless driver in a Cloudflare Worker, **[see here.](http://driz.link/neon-cf-ex)**  
-To use Neon from a serverful environment, you can use the PostgresJS driver, as described in Neon's **[official Node.js docs](https://neon.tech/docs/guides/node)** — see **[docs](#postgresjs)**.
+For an example of using Drizzle ORM with the Neon Serverless driver in a Cloudflare Worker, **[see here.](https://github.com/drizzle-team/neon-cf-example)**  
+To use Neon from a serverful environment, you can use the PostgresJS driver, as described in Neon's **[official Node.js docs](https://neon.tech/docs/guides/node).
 
 #### Step 1 - Install packages
 <Npm>


### PR DESCRIPTION
- Just replace the neon cloudflare example broken link to the current one.
- Remove same page reference text/link from the doc