### PR TITLE
fix: "pglight" typo

### DIFF
--- a/src/content/docs/drizzle-kit-pull.mdx
+++ b/src/content/docs/drizzle-kit-pull.mdx
@@ -116,7 +116,7 @@ Drizzle Kit does not come with a pre-bundled database driver,
 it will automatically pick available database driver from your current project based on the `dialect` - [see discussion](https://github.com/drizzle-team/drizzle-orm/discussions/2203).
 
 Mostly all drivers of the same dialect share the same set of connection params, 
-as for exceptions like `aws-data-api`, `pglight` and `d1-http` - you will have to explicitely specify `driver` param.
+as for exceptions like `aws-data-api`, `pglite` and `d1-http` - you will have to explicitely specify `driver` param.
 
 <CodeTabs items={["AWS Data API", "PGLite", "Cloudflare D1 HTTP"]}>
 ```ts {6}

--- a/src/content/docs/drizzle-kit-push.mdx
+++ b/src/content/docs/drizzle-kit-push.mdx
@@ -134,7 +134,7 @@ Drizzle Kit does not come with a pre-bundled database driver,
 it will automatically pick available database driver from your current project based on the `dialect` - [see discussion](https://github.com/drizzle-team/drizzle-orm/discussions/2203).
 
 Mostly all drivers of the same dialect share the same set of connection params, 
-as for exceptions like `aws-data-api`, `pglight` and `d1-http` - you will have to explicitly specify `driver` param.
+as for exceptions like `aws-data-api`, `pglite` and `d1-http` - you will have to explicitly specify `driver` param.
 
 <DriversExamples/>
 

--- a/src/mdx/Drivers.mdx
+++ b/src/mdx/Drivers.mdx
@@ -1,5 +1,5 @@
 ---
-drivers: ['aws-data-api', 'd1-http', 'pglight']
+drivers: ['aws-data-api', 'd1-http', 'pglite']
 ---
 
 {frontmatter.drivers.map((driver) => <><code>{driver}</code>&#32;</>)}


### PR DESCRIPTION
closes #615 
Quick fix of typos of "pglight" into the correct spelling ("pglite") across three files :)