### PR TITLE
fix: wrong import

### DIFF
--- a/src/content/docs/column-types/sqlite.mdx
+++ b/src/content/docs/column-types/sqlite.mdx
@@ -215,7 +215,7 @@ CREATE TABLE `table` (
 
 <Section>
 ```typescript
-import { blob, sqliteTable } from "drizzle-orm/sqlite-core";
+import { numeric, sqliteTable } from "drizzle-orm/sqlite-core";
 
 const table = sqliteTable('table', {
 	numeric: numeric(),


### PR DESCRIPTION
The current version is referencing `numeric` in the code but imports `blob` from above. This commit fixes it.