### PR TITLE
fix: Correct relation reference in user query example

### DIFF
--- a/src/content/docs/rqb-v2.mdx
+++ b/src/content/docs/rqb-v2.mdx
@@ -90,7 +90,7 @@ We've made sure you have both the best-in-class developer experience and perform
         }),
       },
       users: {
-        posts: r.many.users(),
+        posts: r.many.posts(),
       },
     }));
 	```


### PR DESCRIPTION
This pull request makes a small correction to the data model definition, fixing a relationship in the code to reference the correct entity.

- Changed the `users.posts` relationship to correctly reference `r.many.posts()` instead of `r.many.users()` in the example data model (`src/content/docs/rqb-v2.mdx`).
- https://orm.drizzle.team/docs/rqb-v2

<img width="848" height="587" alt="Screenshot 2025-12-15 at 13 27 07" src="https://github.com/user-attachments/assets/26e691de-865a-480c-875b-fcac4a0adf33" />
