### PR TITLE
support passing `driver` to SetupEnv

### DIFF
--- a/src/content/docs/get-started/pglite-new.mdx
+++ b/src/content/docs/get-started/pglite-new.mdx
@@ -47,7 +47,7 @@ import SetupEnv from '@mdx/get-started/SetupEnv.mdx';
 
 #### Step 5 - Setup Drizzle config file
 
-<SetupConfig dialect='postgresql' env_variable='DATABASE_URL'/>
+<SetupConfig dialect='postgresql' env_variable='DATABASE_URL' driver='pglite'/>
 
 #### Step 6 - Applying changes to the database
 

--- a/src/mdx/get-started/SetupConfig.mdx
+++ b/src/mdx/get-started/SetupConfig.mdx
@@ -4,7 +4,7 @@ import CodeWithProps from "@mdx/CodeWithProps.astro";
 
 Create a `drizzle.config.ts` file in the root of your project and add the following content:
 
-<CodeWithProps dialect={props.dialect} env_variable={props.env_variable}>
+<CodeWithProps dialect={props.dialect} env_variable={props.env_variable} driverLine={props.driver ? `\n  driver: '${props.driver}',\n` : ''}>
 ```typescript copy filename="drizzle.config.ts"
 import 'dotenv/config';
 import { defineConfig } from 'drizzle-kit';
@@ -12,7 +12,7 @@ import { defineConfig } from 'drizzle-kit';
 export default defineConfig({
   out: './drizzle',
   schema: './src/db/schema.ts',
-  dialect: '$dialect$',
+  dialect: '$dialect$',$driverLine$
   dbCredentials: {
     url: process.env.$env_variable$!,
   },


### PR DESCRIPTION
and facilitate this feature to add `driver: 'pglite'` to pglite-new doc

The PR will change `Step 5 - Setup Drizzle config file` section of pglite-new page to:
<img width="1724" height="962" alt="CleanShot 2025-12-20 at 11 09 53@2x" src="https://github.com/user-attachments/assets/a10c7e7b-2be2-4ea2-8f0e-5a429ae68013" />

Though this line is not syntax-highlighted due to the limitation of the current string replacement implementation in CodeWithProps componemt, which I tried a lot of ways but not able to enhance, this PR at least correct what the doc is missing (ref: https://github.com/drizzle-team/drizzle-orm/discussions/2532)