### PR TITLE
docs: update broken Neon Cloudflare Workers example link

### DIFF
--- a/src/content/docs/connect-neon.mdx
+++ b/src/content/docs/connect-neon.mdx
@@ -25,7 +25,7 @@ Querying over HTTP is faster for single, non-interactive transactions.
 If you need session or interactive transaction support, or a fully compatible drop-in replacement for the `pg` driver, you can use the WebSocket-based `neon-serverless` driver.  
 You can connect to a Neon database directly using [Postgres](/docs/get-started/postgresql-new)
   
-For an example of using Drizzle ORM with the Neon Serverless driver in a Cloudflare Worker, **[see here.](http://driz.link/neon-cf-ex)**  
+For an example of using Drizzle ORM with the Neon Serverless driver in a Cloudflare Worker, **[see here.](https://github.com/neondatabase-labs/cloudflare-drizzle-neon)**  
 To use Neon from a serverful environment, you can use the PostgresJS driver, as described in Neon's **[official Node.js docs](https://neon.tech/docs/guides/node)** — see **[docs](#postgresjs)**.
 
 #### Step 1 - Install packages


### PR DESCRIPTION
## Summary
Fixed the broken link in the Neon connection documentation that was causing a 404 error.

## Changes
- Updated the broken shortlink `http://driz.link/neon-cf-ex` with the correct GitHub repository URL
- New link points to: https://github.com/neondatabase-labs/cloudflare-drizzle-neon

## Details
The original shortlink was returning a 404 error. The new link points to an active example repository maintained by neondatabase-labs that demonstrates using Drizzle ORM with the Neon Serverless driver in a Cloudflare Worker.

This repository includes:
- Cloudflare Workers with Hono.js
- Drizzle ORM integration
- Neon Serverless driver usage
- Complete setup instructions
- Working example code

Closes: drizzle-team/drizzle-orm#5155
Related: drizzle-team/drizzle-orm-docs#598