### PR TITLE
fix(docs): correct MSSQL insert output() call order

### DIFF
--- a/src/content/docs/insert.mdx
+++ b/src/content/docs/insert.mdx
@@ -79,12 +79,12 @@ const result = await db.insert(usersTableDefFn).values([{ name: 'John' }, { name
 
 ## output
 <IsSupportedChipGroup chips={{ 'MSSQL': true }} />
-You can insert a row and get it back in PostgreSQL and SQLite like such:
+You can insert a row and get it back in MSSQL using `.output()`. Note that `.output()` must be called **before** `.values()`, as this mirrors the MSSQL SQL syntax where `OUTPUT` precedes the `VALUES` clause:
 ```typescript copy
-await db.insert(users).values({ name: "Dan" }).output();
+await db.insert(users).output().values({ name: "Dan" });
 
 // partial return
-await db.insert(users).values({ name: "Partial Dan" }).output({ insertedId: users.id });
+await db.insert(users).output({ insertedId: users.id }).values({ name: "Partial Dan" });
 ```
 
 ## Insert multiple rows


### PR DESCRIPTION
## Summary

Fixes drizzle-team/drizzle-orm#5472

The `insert.mdx` docs show `.output()` called **after** `.values()`, which throws a runtime error. Per MSSQL SQL syntax (and the Drizzle API implementation), `OUTPUT` must come **before** `VALUES`:

```sql
-- MSSQL SQL structure:
INSERT INTO users OUTPUT INSERTED.id VALUES ('Dan')
```

This is confirmed by maintainer [@AleksandrSherman](https://github.com/drizzle-team/drizzle-orm/issues/5472#issuecomment-2721696527): _"The use of the `output` clause in mssql is based directly on the official mssql documentation... But it seems that docs have an incorrect example. We will update that."_

## Changes

**Before:**
```typescript
await db.insert(users).values({ name: "Dan" }).output();
await db.insert(users).values({ name: "Partial Dan" }).output({ insertedId: users.id });
```

**After:**
```typescript
await db.insert(users).output().values({ name: "Dan" });
await db.insert(users).output({ insertedId: users.id }).values({ name: "Partial Dan" });
```

Also corrected the description which incorrectly said "PostgreSQL and SQLite" instead of "MSSQL".