### PR TITLE
fix: correct Database to DatabaseSync in node:sqlite docs

### DIFF
--- a/src/content/docs/connect-node-sqlite.mdx
+++ b/src/content/docs/connect-node-sqlite.mdx
@@ -51,7 +51,7 @@ If you want to use **sync** APIs:
 import { drizzle } from 'drizzle-orm/node-sqlite';
 import { DatabaseSync } from 'node:sqlite';
 
-const sqlite = new Database('sqlite.db');
+const sqlite = new DatabaseSync('sqlite.db');
 const db = drizzle({ client: sqlite });
 
 const result = db.select().from(users).all();


### PR DESCRIPTION
Hey team! 👋

Just noticed a small typo in the [node:sqlite documentation](https://orm.drizzle.team/docs/connect-node-sqlite). In the sync API example, it imports ```DatabaseSync``` but then uses ```new Database()```:
```typescript
import { DatabaseSync } from 'node:sqlite';
const sqlite = new Database('sqlite.db'); // Should be DatabaseSync
```
Should be:
```typescript
const sqlite = new DatabaseSync('sqlite.db');
```
Not a big deal since it's clear from context, but might confuse newcomers! 😊

P.S. Really appreciate all the work on v1.0! The type system improvements look amazing. 🚀