### PR TITLE
docs: remove dotenv from drizzle.config.ts examples

### DIFF
--- a/src/content/docs/tutorials/drizzle-with-db/drizzle-with-neon.mdx
+++ b/src/content/docs/tutorials/drizzle-with-db/drizzle-with-neon.mdx
@@ -109,10 +109,7 @@ export type SelectPost = typeof postsTable.$inferSelect;
 Create a `drizzle.config.ts` file in the root of your project and add the following content:
 
 ```typescript copy filename="drizzle.config.ts"
-import { config } from 'dotenv';
 import { defineConfig } from "drizzle-kit";
-
-config({ path: '.env' });
 
 export default defineConfig({
   schema: "./src/schema.ts",

--- a/src/content/docs/tutorials/drizzle-with-db/drizzle-with-supabase.mdx
+++ b/src/content/docs/tutorials/drizzle-with-db/drizzle-with-supabase.mdx
@@ -108,10 +108,7 @@ export type SelectPost = typeof postsTable.$inferSelect;
 Create a `drizzle.config.ts` file in the root of your project and add the following content:
 
 ```typescript copy filename="drizzle.config.ts"
-import { config } from 'dotenv';
 import { defineConfig } from 'drizzle-kit';
-
-config({ path: '.env' });
 
 export default defineConfig({
   schema: './src/db/schema.ts',

--- a/src/content/docs/tutorials/drizzle-with-db/drizzle-with-turso.mdx
+++ b/src/content/docs/tutorials/drizzle-with-db/drizzle-with-turso.mdx
@@ -144,10 +144,7 @@ export type SelectPost = typeof postsTable.$inferSelect;
 Create a `drizzle.config.ts` file in the root of your project and add the following content:
 
 ```typescript copy filename="drizzle.config.ts"
-import { config } from 'dotenv';
 import { defineConfig } from 'drizzle-kit';
-
-config({ path: '.env' });
 
 export default defineConfig({
   schema: './src/db/schema.ts',

--- a/src/content/docs/tutorials/drizzle-with-db/drizzle-with-vercel.mdx
+++ b/src/content/docs/tutorials/drizzle-with-db/drizzle-with-vercel.mdx
@@ -106,10 +106,7 @@ export type SelectPost = typeof postsTable.$inferSelect;
 Create a `drizzle.config.ts` file in the root of your project and add the following content:
 
 ```typescript copy filename="drizzle.config.ts"
-import { config } from 'dotenv';
 import { defineConfig } from 'drizzle-kit';
-
-config({ path: '.env.local' });
 
 export default defineConfig({
   schema: './src/db/schema.ts',

--- a/src/content/docs/tutorials/drizzle-with-db/drizzle-with-xata.mdx
+++ b/src/content/docs/tutorials/drizzle-with-db/drizzle-with-xata.mdx
@@ -125,10 +125,7 @@ export type SelectPost = typeof postsTable.$inferSelect;
 Create a `drizzle.config.ts` file in the root of your project and add the following content:
 
 ```typescript copy filename="drizzle.config.ts"
-import { config } from 'dotenv';
 import { defineConfig } from 'drizzle-kit';
-
-config({ path: '.env' });
 
 export default defineConfig({
   schema: './src/db/schema.ts',

--- a/src/content/docs/tutorials/drizzle-with-frameworks/drizzle-nextjs-neon.mdx
+++ b/src/content/docs/tutorials/drizzle-with-frameworks/drizzle-nextjs-neon.mdx
@@ -102,10 +102,7 @@ Here we define the **`todo`** table with fields **`id`**, **`text`**, and **`don
 Create a `drizzle.config.ts` file in the root of your project and add the following content:
 
 ```typescript copy filename="drizzle.config.ts"
-import { config } from 'dotenv';
 import { defineConfig } from "drizzle-kit";
-
-config({ path: '.env' });
 
 export default defineConfig({
   schema: "./src/db/schema.ts",


### PR DESCRIPTION
Closes #5725

drizzle-kit auto-loads `.env` since v0.20.0, so calling `dotenv.config()` inside `drizzle.config.ts` is no longer necessary.

This PR removes the `dotenv` import and `config({ path: '...' })` call from the `drizzle.config.ts` snippets in 6 tutorials. The `src/db/index.ts` blocks still keep dotenv, since application code legitimately needs it at runtime.

Files touched:
- drizzle-with-neon
- drizzle-with-supabase
- drizzle-with-turso
- drizzle-with-vercel
- drizzle-with-xata
- drizzle-nextjs-neon

18 deletions total, no other changes.