### PR TITLE
fix: correct link syntax in table of contents for v2 features

### DIFF
--- a/src/content/docs/relations-v1-v2.mdx
+++ b/src/content/docs/relations-v1-v2.mdx
@@ -30,7 +30,7 @@ drizzle-kit@beta -D
 Below is the table of contents. Click an item to jump to that section:
 
 - [What is working differently from v1](#what-was-changed-and-is-working-differently-from-v1)  
-- [New features in v2](2#what-is-new)  
+- [New features in v2](#what-is-new)  
 - [How to migrate relations definition from v1 to v2](#how-to-migrate-relations-schema-definition-from-v1-to-v2)  
 - [How to migrate queries from v1 to v2](#how-to-migrate-queries-from-v1-to-v2)  
 - [Partial upgrade, or how to stay on v1 even after an upgrade?](#partial-upgrade-or-how-to-stay-on-rqb-v1-even-after-an-upgrade)  


### PR DESCRIPTION
<img width="648" height="240" alt="image" src="https://github.com/user-attachments/assets/c81d38f4-a722-4947-ac0c-5948d37561a0" />
fix: correct link syntax in table of contents for v2 features
