### PR TITLE
docs: remove dotenv call from Turso config

### DIFF
--- a/src/content/docs/tutorials/drizzle-with-db/drizzle-with-turso.mdx
+++ b/src/content/docs/tutorials/drizzle-with-db/drizzle-with-turso.mdx
@@ -144,10 +144,7 @@ export type SelectPost = typeof postsTable.$inferSelect;
 Create a `drizzle.config.ts` file in the root of your project and add the following content:
 
 ```typescript copy filename="drizzle.config.ts"
-import { config } from 'dotenv';
 import { defineConfig } from 'drizzle-kit';
-
-config({ path: '.env' });
 
 export default defineConfig({
   schema: './src/db/schema.ts',


### PR DESCRIPTION
## Summary

Removes the manual `dotenv` import and `config({ path: '.env' })` call from the Turso tutorial's `drizzle.config.ts` snippet.

Drizzle Kit already loads environment variables before reading `drizzle.config.ts`.

Fixes drizzle-team/drizzle-orm#5725

## Checks

- `pnpm run build` passed
- `pnpm test` failed due to an unrelated existing issue: `tests/snake.test.ts` imports missing `../components/landing/header/snake/mapSnake`
