### PR TITLE
docs: document prefix attribute in drizzle.config migrations section

### DIFF
--- a/src/content/docs/drizzle-config-file.mdx
+++ b/src/content/docs/drizzle-config-file.mdx
@@ -374,8 +374,8 @@ successfully applied migrations in your database in log table named `__drizzle_m
 
 |               |                      |
 | :------------ | :-----------------   |
-| type          | `{ table: string, schema: string }` |
-| default       | `{ table: "__drizzle_migrations", schema: "drizzle" }`                    |
+| type          | `{ table: string, schema: string, prefix: "index" \| "timestamp" \| "supabase" \| "unix" \| "none" }` |
+| default       | `{ table: "__drizzle_migrations", schema: "drizzle", prefix: "index" }`                    |
 | commands      | `migrate`   |
 
 <rem025/>


### PR DESCRIPTION
Closes drizzle-team/drizzle-orm#5325.

Added missing 'prefix' attribute documentation to the migrations section. The prefix attribute accepts: index, timestamp, supabase, unix, or none. Updated type definition and default value.