### PR TITLE
fix: broken tsx link

### DIFF
--- a/src/content/docs/get-started/bun-sqlite-existing.mdx
+++ b/src/content/docs/get-started/bun-sqlite-existing.mdx
@@ -24,7 +24,7 @@ import UpdateSchema from '@mdx/get-started/sqlite/UpdateSchema.mdx';
 
 <Prerequisites>  
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
   - **bun** - javaScript all-in-one toolkit - [read here](https://bun.sh/)
   - **bun:sqlite** - native implementation of a high-performance SQLite3 driver - [read here](https://bun.sh/docs/api/sqlite)
 </Prerequisites>

--- a/src/content/docs/get-started/cockroach-existing.mdx
+++ b/src/content/docs/get-started/cockroach-existing.mdx
@@ -32,7 +32,7 @@ This page explains concepts available on drizzle versions `1.0.0-beta.2` and hig
 
 <Prerequisites>
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
   - **node-postgres** - package for querying your PostgreSQL database - [read here](https://node-postgres.com/)
 </Prerequisites>
 

--- a/src/content/docs/get-started/cockroach-new.mdx
+++ b/src/content/docs/get-started/cockroach-new.mdx
@@ -29,7 +29,7 @@ This page explains concepts available on drizzle versions `1.0.0-beta.2` and hig
 
 <Prerequisites>
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
   - **node-postgres** - package for querying your PostgreSQL database - [read here](https://node-postgres.com/)
 </Prerequisites>
 

--- a/src/content/docs/get-started/d1-existing.mdx
+++ b/src/content/docs/get-started/d1-existing.mdx
@@ -26,7 +26,7 @@ import UpdateSchema from '@mdx/get-started/sqlite/UpdateSchema.mdx';
 
 <Prerequisites>
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
   - **Cloudflare D1** - Serverless SQL database to query from your Workers and Pages projects - [read here](https://developers.cloudflare.com/d1/)
   - **wrangler** - Cloudflare Developer Platform command-line interface - [read here](https://developers.cloudflare.com/workers/wrangler)
 </Prerequisites>

--- a/src/content/docs/get-started/d1-new.mdx
+++ b/src/content/docs/get-started/d1-new.mdx
@@ -23,7 +23,7 @@ import ConnectLibsql from '@mdx/get-started/sqlite/ConnectLibsql.mdx';
 
 <Prerequisites>  
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
   - **Cloudflare D1** - Serverless SQL database to query from your Workers and Pages projects - [read here](https://developers.cloudflare.com/d1/)
   - **wrangler** - Cloudflare Developer Platform command-line interface - [read here](https://developers.cloudflare.com/workers/wrangler)
 </Prerequisites>

--- a/src/content/docs/get-started/do-existing.mdx
+++ b/src/content/docs/get-started/do-existing.mdx
@@ -26,7 +26,7 @@ import UpdateSchema from '@mdx/get-started/sqlite/UpdateSchema.mdx';
 
 <Prerequisites>
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
   - **Cloudflare SQLite Durable Objects** - SQLite database embedded within a Durable Object - [read here](https://developers.cloudflare.com/durable-objects/api/sql-storage/)
   - **wrangler** - Cloudflare Developer Platform command-line interface - [read here](https://developers.cloudflare.com/workers/wrangler)
 </Prerequisites>

--- a/src/content/docs/get-started/do-new.mdx
+++ b/src/content/docs/get-started/do-new.mdx
@@ -23,7 +23,7 @@ import ConnectLibsql from '@mdx/get-started/sqlite/ConnectLibsql.mdx';
 
 <Prerequisites>  
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
   - **Cloudflare SQLite Durable Objects** - SQLite database embedded within a Durable Object - [read here](https://developers.cloudflare.com/durable-objects/api/sql-storage/)
   - **wrangler** - Cloudflare Developer Platform command-line interface - [read here](https://developers.cloudflare.com/workers/wrangler)
 </Prerequisites>

--- a/src/content/docs/get-started/effect-postgresql-existing.mdx
+++ b/src/content/docs/get-started/effect-postgresql-existing.mdx
@@ -33,7 +33,7 @@ On how to upgrade (read more [here](/docs/upgrade-v1))
 <Prerequisites>
   - **Effect** - Effect is a powerful TS library designed to help developers easily create complex, synchronous, and asynchronous programs. - [read more](https://effect.website/docs)
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
   - **@effect/sql-pg** - A PostgreSQL toolkit for Effect - [read here](https://effect-ts.github.io/effect/docs/sql-pg)
 </Prerequisites>
 

--- a/src/content/docs/get-started/effect-postgresql-new.mdx
+++ b/src/content/docs/get-started/effect-postgresql-new.mdx
@@ -32,7 +32,7 @@ On how to upgrade (read more [here](/docs/upgrade-v1))
 <Prerequisites>
   - **Effect** - Effect is a powerful TS library designed to help developers easily create complex, synchronous, and asynchronous programs. - [read more](https://effect.website/docs)
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
   - **@effect/sql-pg** - A PostgreSQL toolkit for Effect - [read here](https://effect-ts.github.io/effect/docs/sql-pg)
 </Prerequisites>
 

--- a/src/content/docs/get-started/gel-existing.mdx
+++ b/src/content/docs/get-started/gel-existing.mdx
@@ -23,7 +23,7 @@ import SetupEnv from '@mdx/get-started/SetupEnv.mdx';
 # Get Started with Drizzle and Gel in existing project
 
 <Prerequisites>
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
   - **gel-js** - package for querying your Gel database - [read here](https://github.com/geldata/gel-js)
 </Prerequisites>
 

--- a/src/content/docs/get-started/gel-new.mdx
+++ b/src/content/docs/get-started/gel-new.mdx
@@ -23,7 +23,7 @@ import SetupEnv from '@mdx/get-started/SetupEnv.mdx';
 # Get Started with Drizzle and Gel
 
 <Prerequisites>
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
   - **gel-js** - package for querying your Gel database - [read here](https://github.com/geldata/gel-js)
 </Prerequisites>
 

--- a/src/content/docs/get-started/mssql-existing.mdx
+++ b/src/content/docs/get-started/mssql-existing.mdx
@@ -32,7 +32,7 @@ This page explains concepts available on drizzle versions `1.0.0-beta.2` and hig
 
 <Prerequisites>
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
   - **node-mssql** - package for querying your MSSQL database - [read here](https://github.com/tediousjs/node-mssql)
 </Prerequisites>
 

--- a/src/content/docs/get-started/mssql-new.mdx
+++ b/src/content/docs/get-started/mssql-new.mdx
@@ -29,7 +29,7 @@ This page explains concepts available on drizzle versions `1.0.0-beta.2` and hig
 
 <Prerequisites>
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
   - **node-mssql** - package for querying your MSSQL database - [read here](https://github.com/tediousjs/node-mssql)
 </Prerequisites>
 

--- a/src/content/docs/get-started/mysql-existing.mdx
+++ b/src/content/docs/get-started/mysql-existing.mdx
@@ -24,7 +24,7 @@ import TransferCode from '@mdx/get-started/TransferCode.mdx';
 
 <Prerequisites>  
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
   - **mysql2** - package for querying your MySQL database - [read here](https://github.com/sidorares/node-mysql2)
 </Prerequisites>
 

--- a/src/content/docs/get-started/mysql-new.mdx
+++ b/src/content/docs/get-started/mysql-new.mdx
@@ -20,7 +20,7 @@ import SetupConfig from '@mdx/get-started/SetupConfig.mdx';
 
 <Prerequisites>  
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
   - **mysql2** - package for querying your MySQL database - [read here](https://github.com/sidorares/node-mysql2)
 </Prerequisites>
 

--- a/src/content/docs/get-started/neon-existing.mdx
+++ b/src/content/docs/get-started/neon-existing.mdx
@@ -26,7 +26,7 @@ import UpdateSchema from '@mdx/get-started/postgresql/UpdateSchema.mdx';
 
 <Prerequisites>
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
   - **Neon** - serverless Postgres platform - [read here](https://neon.tech/docs/introduction)
 </Prerequisites>
 

--- a/src/content/docs/get-started/neon-new.mdx
+++ b/src/content/docs/get-started/neon-new.mdx
@@ -23,7 +23,7 @@ import SetupEnv from '@mdx/get-started/SetupEnv.mdx';
 
 <Prerequisites>
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
   - **Neon** - serverless Postgres platform - [read here](https://neon.tech/docs/introduction)
 </Prerequisites>
 

--- a/src/content/docs/get-started/nile-existing.mdx
+++ b/src/content/docs/get-started/nile-existing.mdx
@@ -26,7 +26,7 @@ import UpdateSchema from '@mdx/get-started/postgresql/UpdateSchema.mdx';
 
 <Prerequisites>
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
   - **Nile** - PostgreSQL re-engineered for multi-tenant apps - [read here](https://thenile.dev/)
 </Prerequisites>
 

--- a/src/content/docs/get-started/nile-new.mdx
+++ b/src/content/docs/get-started/nile-new.mdx
@@ -24,7 +24,7 @@ import SetupEnv from '@mdx/get-started/SetupEnv.mdx';
 
 <Prerequisites>
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
   - **Nile** - PostgreSQL re-engineered for multi-tenant apps - [read here](https://thenile.dev/)
 </Prerequisites>
 

--- a/src/content/docs/get-started/node-sqlite-existing.mdx
+++ b/src/content/docs/get-started/node-sqlite-existing.mdx
@@ -26,7 +26,7 @@ import UpdateSchema from '@mdx/get-started/sqlite/UpdateSchema.mdx';
   - **node v22.5.0+** - JavaScript runtime - [read here](https://nodejs.org/)
   - **node:sqlite** - native implementation of a high-performance SQLite3 driver - [read here](https://nodejs.org/api/sqlite.html)
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
 </Prerequisites>
 
 <FileStructure />

--- a/src/content/docs/get-started/pglite-existing.mdx
+++ b/src/content/docs/get-started/pglite-existing.mdx
@@ -26,7 +26,7 @@ import UpdateSchema from '@mdx/get-started/postgresql/UpdateSchema.mdx';
 
 <Prerequisites>
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
   - **ElectricSQL** - [website](https://electric-sql.com/)
   - **pglite driver** - [docs](https://pglite.dev/) & [GitHub](https://github.com/electric-sql/pglite)
 </Prerequisites>

--- a/src/content/docs/get-started/pglite-new.mdx
+++ b/src/content/docs/get-started/pglite-new.mdx
@@ -23,7 +23,7 @@ import SetupEnv from '@mdx/get-started/SetupEnv.mdx';
 
 <Prerequisites>
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
   - **ElectricSQL** - [website](https://electric-sql.com/)
   - **pglite driver** - [docs](https://pglite.dev/) & [GitHub](https://github.com/electric-sql/pglite)
 </Prerequisites>

--- a/src/content/docs/get-started/planetscale-existing.mdx
+++ b/src/content/docs/get-started/planetscale-existing.mdx
@@ -23,7 +23,7 @@ import TransferCode from '@mdx/get-started/TransferCode.mdx';
 
 <Prerequisites>  
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io)
   - **PlanetScale** - MySQL database platform - [read here](https://planetscale.com)
   - **database-js** - PlanetScale serverless driver - [read here](https://github.com/planetscale/database-js)
 </Prerequisites>

--- a/src/content/docs/get-started/planetscale-new.mdx
+++ b/src/content/docs/get-started/planetscale-new.mdx
@@ -20,7 +20,7 @@ import SetupConfig from '@mdx/get-started/SetupConfig.mdx';
 
 <Prerequisites>  
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io)
   - **PlanetScale** - MySQL database platform - [read here](https://planetscale.com)
   - **database-js** - PlanetScale serverless driver - [read here](https://github.com/planetscale/database-js)
 </Prerequisites>

--- a/src/content/docs/get-started/planetscale-postgres-existing.mdx
+++ b/src/content/docs/get-started/planetscale-postgres-existing.mdx
@@ -26,7 +26,7 @@ import UpdateSchema from '@mdx/get-started/postgresql/UpdateSchema.mdx';
 
 <Prerequisites>
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
   - **PlanetScale Postgres** - PostgreSQL database platform - [read here](https://planetscale.com/docs/postgres)
   - **node-postgres** - package for querying your PostgreSQL database - [read here](https://node-postgres.com/)
 </Prerequisites>

--- a/src/content/docs/get-started/planetscale-postgres-new.mdx
+++ b/src/content/docs/get-started/planetscale-postgres-new.mdx
@@ -23,7 +23,7 @@ import SetupEnv from '@mdx/get-started/SetupEnv.mdx';
 
 <Prerequisites>
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
   - **PlanetScale Postgres** - PostgreSQL database platform - [read here](https://planetscale.com/docs/postgres)
   - **node-postgres** - package for querying your PostgreSQL database - [read here](https://node-postgres.com/)
 </Prerequisites>

--- a/src/content/docs/get-started/postgresql-existing.mdx
+++ b/src/content/docs/get-started/postgresql-existing.mdx
@@ -26,7 +26,7 @@ import UpdateSchema from '@mdx/get-started/postgresql/UpdateSchema.mdx';
 
 <Prerequisites>
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
   - **node-postgres** - package for querying your PostgreSQL database - [read here](https://node-postgres.com/)
 </Prerequisites>
 

--- a/src/content/docs/get-started/postgresql-new.mdx
+++ b/src/content/docs/get-started/postgresql-new.mdx
@@ -23,7 +23,7 @@ import SetupEnv from '@mdx/get-started/SetupEnv.mdx';
 
 <Prerequisites>
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
   - **node-postgres** - package for querying your PostgreSQL database - [read here](https://node-postgres.com/)
 </Prerequisites>
 

--- a/src/content/docs/get-started/singlestore-existing.mdx
+++ b/src/content/docs/get-started/singlestore-existing.mdx
@@ -23,7 +23,7 @@ import TransferCode from '@mdx/get-started/TransferCode.mdx';
 
 <Prerequisites>  
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
   - **mysql2** - package for querying your SingleStore database - [read here](https://github.com/sidorares/node-mysql2)
 </Prerequisites>
 

--- a/src/content/docs/get-started/singlestore-new.mdx
+++ b/src/content/docs/get-started/singlestore-new.mdx
@@ -20,7 +20,7 @@ import SetupConfig from '@mdx/get-started/SetupConfig.mdx';
 
 <Prerequisites>  
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
   - **mysql2** - package for querying your MySQL database - [read here](https://github.com/sidorares/node-mysql2)
 </Prerequisites>
 

--- a/src/content/docs/get-started/sqlite-cloud-existing.mdx
+++ b/src/content/docs/get-started/sqlite-cloud-existing.mdx
@@ -26,7 +26,7 @@ import UpdateSchema from '@mdx/get-started/sqlite/UpdateSchema.mdx';
 
 <Prerequisites>
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
   - **SQLite Cloud database** - [read here](https://docs.sqlitecloud.io/docs/overview)
   - **SQLite Cloud driver** - [read here](https://docs.sqlitecloud.io/docs/sdk-js-introduction) & [GitHub](https://github.com/sqlitecloud/sqlitecloud-js)
 </Prerequisites>

--- a/src/content/docs/get-started/sqlite-cloud-new.mdx
+++ b/src/content/docs/get-started/sqlite-cloud-new.mdx
@@ -23,7 +23,7 @@ import SetupEnv from '@mdx/get-started/SetupEnv.mdx';
 
 <Prerequisites>
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
   - **SQLite Cloud database** - [read here](https://docs.sqlitecloud.io/docs/overview)
   - **SQLite Cloud driver** - [read here](https://docs.sqlitecloud.io/docs/sdk-js-introduction) & [GitHub](https://github.com/sqlitecloud/sqlitecloud-js)
 </Prerequisites>

--- a/src/content/docs/get-started/sqlite-existing.mdx
+++ b/src/content/docs/get-started/sqlite-existing.mdx
@@ -24,7 +24,7 @@ import UpdateSchema from '@mdx/get-started/sqlite/UpdateSchema.mdx';
 
 <Prerequisites>  
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
   - **libsql** - a fork of SQLite optimized for low query latency, making it suitable for global applications - [read here](https://docs.turso.tech/libsql)
 </Prerequisites>
 

--- a/src/content/docs/get-started/sqlite-new.mdx
+++ b/src/content/docs/get-started/sqlite-new.mdx
@@ -23,7 +23,7 @@ import ConnectLibsql from '@mdx/get-started/sqlite/ConnectLibsql.mdx';
 
 <Prerequisites>  
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
   - **libsql** - a fork of SQLite optimized for low query latency, making it suitable for global applications - [read here](https://docs.turso.tech/libsql)
 </Prerequisites>
 

--- a/src/content/docs/get-started/supabase-existing.mdx
+++ b/src/content/docs/get-started/supabase-existing.mdx
@@ -26,7 +26,7 @@ import UpdateSchema from '@mdx/get-started/postgresql/UpdateSchema.mdx';
 
 <Prerequisites>
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
   - **Supabase** - open source Firebase alternative - [read here](https://supabase.com/)
 </Prerequisites>
 

--- a/src/content/docs/get-started/supabase-new.mdx
+++ b/src/content/docs/get-started/supabase-new.mdx
@@ -23,7 +23,7 @@ import SetupEnv from '@mdx/get-started/SetupEnv.mdx';
 
 <Prerequisites>
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
   - **Supabase** - open source Firebase alternative - [read here](https://supabase.com/)
 </Prerequisites>
 

--- a/src/content/docs/get-started/tidb-existing.mdx
+++ b/src/content/docs/get-started/tidb-existing.mdx
@@ -24,7 +24,7 @@ import TransferCode from '@mdx/get-started/TransferCode.mdx';
 
 <Prerequisites>  
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
   - **TiDB** - The Distributed SQL Database by PingCAP - [read here](https://www.pingcap.com/)
   - **serverless-js** - package for serverless and edge compute platforms that require HTTP external connections - [read here](https://github.com/tidbcloud/serverless-js)
 </Prerequisites>

--- a/src/content/docs/get-started/tidb-new.mdx
+++ b/src/content/docs/get-started/tidb-new.mdx
@@ -20,7 +20,7 @@ import SetupConfig from '@mdx/get-started/SetupConfig.mdx';
 
 <Prerequisites>  
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
   - **TiDB** - The Distributed SQL Database by PingCAP - [read here](https://www.pingcap.com/)
   - **serverless-js** - package for serverless and edge compute platforms that require HTTP external connections - [read here](https://github.com/tidbcloud/serverless-js)
 </Prerequisites>

--- a/src/content/docs/get-started/turso-database-existing.mdx
+++ b/src/content/docs/get-started/turso-database-existing.mdx
@@ -26,7 +26,7 @@ import UpdateSchema from '@mdx/get-started/sqlite/UpdateSchema.mdx';
 
 <Prerequisites>
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
   - Turso Database - [website](https://docs.turso.tech/introduction)
   - Turso Database driver - [website](https://docs.turso.tech/connect/javascript) & [GitHub](https://github.com/tursodatabase/turso/tree/main/bindings/javascript)
 </Prerequisites>

--- a/src/content/docs/get-started/turso-database-new.mdx
+++ b/src/content/docs/get-started/turso-database-new.mdx
@@ -23,7 +23,7 @@ import SetupEnv from '@mdx/get-started/SetupEnv.mdx';
 
 <Prerequisites>
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
   - Turso Database - [website](https://docs.turso.tech/introduction)
   - Turso Database driver - [website](https://docs.turso.tech/connect/javascript) & [GitHub](https://github.com/tursodatabase/turso/tree/main/bindings/javascript)
 </Prerequisites>

--- a/src/content/docs/get-started/turso-existing.mdx
+++ b/src/content/docs/get-started/turso-existing.mdx
@@ -28,7 +28,7 @@ import LibsqlTabs from '@mdx/LibsqlTabs.mdx';
 
 <Prerequisites>  
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
   - **turso** - SQLite for Production - [read here](https://turso.tech/)
   - **libsql** - a fork of SQLite optimized for low query latency, making it suitable for global applications - [read here](https://docs.turso.tech/libsql)
 </Prerequisites>

--- a/src/content/docs/get-started/turso-new.mdx
+++ b/src/content/docs/get-started/turso-new.mdx
@@ -25,7 +25,7 @@ import LibsqlTabs from '@mdx/LibsqlTabs.mdx';
 
 <Prerequisites>  
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
   - **turso** - SQLite for Production - [read here](https://turso.tech/)
   - **libsql** - a fork of SQLite optimized for low query latency, making it suitable for global applications - [read here](https://docs.turso.tech/libsql)
 </Prerequisites>

--- a/src/content/docs/get-started/vercel-existing.mdx
+++ b/src/content/docs/get-started/vercel-existing.mdx
@@ -26,7 +26,7 @@ import UpdateSchema from '@mdx/get-started/postgresql/UpdateSchema.mdx';
 
 <Prerequisites>
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
   - **Vercel Postgres database** - [read here](https://vercel.com/docs/storage/vercel-postgres)
   - **Vercel Postgres driver** - [read here](https://vercel.com/docs/storage/vercel-postgres/sdk) & [GitHub](https://github.com/vercel/storage/tree/main/packages/postgres)
 </Prerequisites>

--- a/src/content/docs/get-started/vercel-new.mdx
+++ b/src/content/docs/get-started/vercel-new.mdx
@@ -23,7 +23,7 @@ import SetupEnv from '@mdx/get-started/SetupEnv.mdx';
 
 <Prerequisites>
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
   - **Vercel Postgres database** - [read here](https://vercel.com/docs/storage/vercel-postgres)
   - **Vercel Postgres driver** - [read here](https://vercel.com/docs/storage/vercel-postgres/sdk) & [GitHub](https://github.com/vercel/storage/tree/main/packages/postgres)
 </Prerequisites>

--- a/src/content/docs/get-started/xata-existing.mdx
+++ b/src/content/docs/get-started/xata-existing.mdx
@@ -26,7 +26,7 @@ import UpdateSchema from '@mdx/get-started/postgresql/UpdateSchema.mdx';
 
 <Prerequisites>
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
   - **Xata Postgres database** - [read here](https://xata.io/documentation)
 </Prerequisites>
 

--- a/src/content/docs/get-started/xata-new.mdx
+++ b/src/content/docs/get-started/xata-new.mdx
@@ -23,7 +23,7 @@ import SetupEnv from '@mdx/get-started/SetupEnv.mdx';
 
 <Prerequisites>
   - **dotenv** - package for managing environment variables - [read here](https://www.npmjs.com/package/dotenv)
-  - **tsx** - package for running TypeScript files - [read here](https://tsx.is/)
+  - **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)
   - **Xata Postgres database** - [read here](https://xata.io/documentation)
 </Prerequisites>
 


### PR DESCRIPTION
This PR fixes #676 

The TSX links in the current docs is redirecting to a different website which hosts Ads. The official TSX website URL has changed to https://tsx.hirok.io/

Reference : 
https://github.com/privatenumber/tsx/issues/786
https://x.com/tsx_is/status/2045857800123990483


**Before** 
`**tsx** - package for running TypeScript files - [read here](https://tsx.is/)`

**After**
`- **tsx** - package for running TypeScript files - [read here](https://tsx.hirok.io/)`

This applies to 46 files which contained the url https://tsx.is
