### PR TITLE
fix(docs): correct drizzle import in Supabase and Xata get-started

### DIFF
--- a/src/mdx/get-started/postgresql/ConnectSupabase.mdx
+++ b/src/mdx/get-started/postgresql/ConnectSupabase.mdx
@@ -3,10 +3,10 @@ import Callout from '@mdx/Callout.astro';
 Create a `index.ts` file in the `src` directory and initialize the connection:
 
 ```typescript copy filename="index.ts"
-import { drizzle } from 'drizzle-orm'
+import { drizzle } from 'drizzle-orm/postgres-js'
 
 async function main() {
-    const db = drizzle('postgres-js', process.env.DATABASE_URL);
+    const db = drizzle(process.env.DATABASE_URL!);
 }
 
 main();

--- a/src/mdx/get-started/postgresql/ConnectXata.mdx
+++ b/src/mdx/get-started/postgresql/ConnectXata.mdx
@@ -1,10 +1,10 @@
 Create a `index.ts` file in the `src` directory and initialize the connection:
 
 ```typescript copy filename="index.ts"
-import { drizzle } from 'drizzle-orm'
+import { drizzle } from 'drizzle-orm/postgres-js'
 
 async function main() {
-    const db = drizzle('postgres-js', process.env.DATABASE_URL);
+    const db = drizzle(process.env.DATABASE_URL!);
 }
 
 main();


### PR DESCRIPTION
Closes drizzle-team/drizzle-orm#3161.

The first connection example on the Supabase and Xata get-started pages has two problems:

- It imports `drizzle` from `drizzle-orm`, which doesn't export it, so you get `Module '"drizzle-orm"' has no exported member 'drizzle'.ts(2305)`.
- It calls `drizzle('postgres-js', process.env.DATABASE_URL)`, but the postgres-js driver's `drizzle` takes a connection string (or client) as the first argument, not a dialect name.

Both pages use the `postgres` driver, so I changed them to import from `drizzle-orm/postgres-js` and pass the connection string directly, matching how the node-postgres get-started page already does it:

```ts
import { drizzle } from 'drizzle-orm/postgres-js'
const db = drizzle(process.env.DATABASE_URL!);
```

#3161 only mentions Supabase, but Xata had the identical broken snippet, so I fixed both. The later examples on these pages already use the correct `drizzle-orm/postgres-js` import, so this just brings the first one in line.