### PR TITLE
fix(docs): correct spread order in defineRelationsPart example

### DIFF
--- a/src/content/docs/relations-v2.mdx
+++ b/src/content/docs/relations-v2.mdx
@@ -565,7 +565,7 @@ Having `{ ...relations, ...part }` will result in
 }
 ```
 
-and having `{ ...relations, ...part }` will result in
+and having `{ ...part, ...relations }` will result in
 ```json
 {
   "users": {"invitee": {...}, "posts": {...}},


### PR DESCRIPTION
The "Why it's important?" callout in the Relations Parts section of the Drizzle Relations (v2) docs shows the same spread order `{ ...relations, ...part }` for both result objects — the one that keeps the relation and the one where "posts relations information will be lost". With identical spread orders the two outcomes are indistinguishable, which is the bug reported in #629.

`defineRelations` seeds an empty placeholder (`posts: {}`) for every table, and object spread is last-key-wins:
- `{ ...relations, ...part }.posts` → `{ author: {...} }` (relation kept)
- `{ ...part, ...relations }.posts` → `{}` (relation lost)

The second example is the "lost" case, so its spread order is corrected to `{ ...part, ...relations }`.

Closes #629
