### PR TITLE
fix(docs): repair broken "Relations Fundamentals" link in relations-v2

### DIFF
--- a/src/content/docs/relations-v2.mdx
+++ b/src/content/docs/relations-v2.mdx
@@ -22,7 +22,7 @@ drizzle-kit@beta -D
 <br/>
 
 <Prerequisites>  
-  - **Relations Fundamentals** - get familiar with the concepts of foreign key constraints, soft relations, database normalization, etc - [read here](/docs/rqb-fundamentals)
+  - **Relations Fundamentals** - get familiar with the concepts of foreign key constraints, soft relations, database normalization, etc - [read here](/docs/relations-schema-declaration)
   - **Declare schema** - get familiar with how to define drizzle schemas - [read here](/docs/sql-schema-declaration)
   - **Database connection** - get familiar with how to connect to database using drizzle - [read here](/docs/get-started-postgresql)
 </Prerequisites>


### PR DESCRIPTION
The "Relations Fundamentals" prerequisite on the Drizzle Relations (v2) page links to `/docs/rqb-fundamentals`, which 404s — it is not a registered docs slug (absent from `src/content/docs/_meta.json`, which `src/pages/[...slug].astro` uses to build routes) and has no backing MDX file.

The "Fundamentals" section of `_meta.json` registers the relations-concepts page as `relations-schema-declaration` (titled "Drizzle Relations Fundamentals"), which covers foreign key constraints, soft relations, and normalization — the exact topics named in the link text. This points the link there.

Closes #638
