### PR TITLE
Add Deno to the package-manager options

### DIFF
--- a/src/mdx/Npm.astro
+++ b/src/mdx/Npm.astro
@@ -1,7 +1,7 @@
 ---
-const items = ["npm", "yarn", "pnpm", "bun"];
+const items = ["npm", "yarn", "pnpm", "bun", "deno"];
 const html = await Astro.slots.render("default");
-const installCommands = ["npm i", "yarn add", "pnpm add", "bun add"];
+const installCommands = ["npm i", "yarn add", "pnpm add", "bun add", "deno add"];
 const installLines = html.replaceAll(/<\/?p>/g, "").replaceAll('—', '--').split("\n");
 
 const getCopyButton = (index: number) => {

--- a/src/mdx/Npx.astro
+++ b/src/mdx/Npx.astro
@@ -1,7 +1,7 @@
 ---
-const items = ["npm", "yarn", "pnpm", "bun"];
+const items = ["npm", "yarn", "pnpm", "bun", "deno"];
 const html = await Astro.slots.render("default");
-const installCommands = ["npx", "yarn", "pnpm", "bunx"];
+const installCommands = ["npx", "yarn", "pnpm", "bunx", "deno run -A"];
 const installLines = html
   .replaceAll(/<\/?p>/g, "")
   .replaceAll("—", "--")

--- a/src/mdx/Npx.astro
+++ b/src/mdx/Npx.astro
@@ -1,7 +1,7 @@
 ---
 const items = ["npm", "yarn", "pnpm", "bun", "deno"];
 const html = await Astro.slots.render("default");
-const installCommands = ["npx", "yarn", "pnpm", "bunx", "deno run -A"];
+const installCommands = ["npx", "yarn", "pnpm", "bunx", "deno x"];
 const installLines = html
   .replaceAll(/<\/?p>/g, "")
   .replaceAll("—", "--")

--- a/src/mdx/NpxCompact.astro
+++ b/src/mdx/NpxCompact.astro
@@ -1,6 +1,6 @@
 ---
 const html = await Astro.slots.render("default");
-const installCommands = ["npx", "yarn", "pnpm", "bun"];
+const installCommands = ["npx", "yarn", "pnpm", "bun", "deno run -A"];
 const installLines = html.replaceAll(/<\/?p>/g, "").replaceAll('—', '--').split("\n");
 const getInstallCommands = () =>
   installLines

--- a/src/mdx/NpxCompact.astro
+++ b/src/mdx/NpxCompact.astro
@@ -1,6 +1,6 @@
 ---
 const html = await Astro.slots.render("default");
-const installCommands = ["npx", "yarn", "pnpm", "bun", "deno run -A"];
+const installCommands = ["npx", "yarn", "pnpm", "bun", "deno x"];
 const installLines = html.replaceAll(/<\/?p>/g, "").replaceAll('—', '--').split("\n");
 const getInstallCommands = () =>
   installLines

--- a/src/ui/CenteredLayout.astro
+++ b/src/ui/CenteredLayout.astro
@@ -137,7 +137,7 @@ const { title, tree } = await getContentTree({
     </script>
     <script is:inline>
       const changeNpmTab = () => {
-        const packageManagers = ["npm", "yarn", "pnpm", "bun"];
+        const packageManagers = ["npm", "yarn", "pnpm", "bun", "deno"];
         // @ts-nocheck
         let packageManagerIndex = packageManagers.indexOf(packageManager);
 
@@ -154,7 +154,7 @@ const { title, tree } = await getContentTree({
           });
 
           npxSelectResizer.querySelector(".line span").innerText =
-            packageManagers[index];
+            npxSelects[0]?.children[index]?.innerText ?? packageManagers[index];
 
           npxSelects.forEach((element) => {
             element.value = index;
@@ -250,7 +250,7 @@ const { title, tree } = await getContentTree({
         const npxSelectResizer = document.querySelector<HTMLDivElement>(
           ".npx-select-resizer",
         );
-        const packageManagers: string[] = ["npm", "yarn", "pnpm", "bun"];
+        const packageManagers: string[] = ["npm", "yarn", "pnpm", "bun", "deno"];
         let packageManager: string =
           localStorage.getItem("package-manager") || "npm";
         let packageManagerIndex: number =
@@ -274,7 +274,7 @@ const { title, tree } = await getContentTree({
           const lineSpan =
             npxSelectResizer?.querySelector<HTMLSpanElement>(".line span");
           if (lineSpan) {
-            lineSpan.innerText = packageManagers[index];
+            lineSpan.innerText = (npxSelects[0]?.children[index] as HTMLElement)?.innerText ?? packageManagers[index];
           }
 
           npxSelects.forEach((element) => {

--- a/src/ui/DocsLayout.astro
+++ b/src/ui/DocsLayout.astro
@@ -208,7 +208,7 @@ const pageHasDialects = Object.keys(dialects).includes(
     </script>
     <script is:inline>
       const changeNpmTab = () => {
-        const packageManagers = ["npm", "yarn", "pnpm", "bun"];
+        const packageManagers = ["npm", "yarn", "pnpm", "bun", "deno"];
 
         let packageManagerIndex = packageManagers.indexOf(packageManager);
 
@@ -225,7 +225,7 @@ const pageHasDialects = Object.keys(dialects).includes(
           });
 
           npxSelectResizer.querySelector(".line span").innerText =
-            packageManagers[index];
+            npxSelects[0]?.children[index]?.innerText ?? packageManagers[index];
 
           npxSelects.forEach((element) => {
             element.value = index;
@@ -446,7 +446,7 @@ const pageHasDialects = Object.keys(dialects).includes(
         const npxSelectResizer = document.querySelector<HTMLDivElement>(
           ".npx-select-resizer",
         );
-        const packageManagers: string[] = ["npm", "yarn", "pnpm", "bun"];
+        const packageManagers: string[] = ["npm", "yarn", "pnpm", "bun", "deno"];
         let packageManager: string =
           localStorage.getItem("package-manager") || "npm";
         let packageManagerIndex: number =
@@ -470,7 +470,7 @@ const pageHasDialects = Object.keys(dialects).includes(
           const lineSpan =
             npxSelectResizer?.querySelector<HTMLSpanElement>(".line span");
           if (lineSpan) {
-            lineSpan.innerText = packageManagers[index];
+            lineSpan.innerText = (npxSelects[0]?.children[index] as HTMLElement)?.innerText ?? packageManagers[index];
           }
 
           npxSelects.forEach((element) => {


### PR DESCRIPTION
👋 Bartek from the Deno team here.

This adds **Deno** as a fifth option to the package-manager widgets, alongside npm / yarn / pnpm / bun. Since the tabs are generated by your shared `<Npm>` / `<Npx>` / `<NpxCompact>` components, Deno now appears on every install/exec snippet across the docs, e.g. on the get-started pages:

```sh
deno add drizzle-orm pg dotenv
```

A few notes on the choices:

- **Install uses `deno add`** to match the surrounding `yarn add` / `pnpm add` / `bun add` style. Deno is a drop-in replacement for npm these days, so `deno add drizzle-orm` works the same way as the others (reads/writes `package.json`).
- **Exec uses `deno x`** (Deno's `npx`/`bunx` equivalent), e.g. `deno x drizzle-kit generate`.
- I kept the package-manager **selector in sync**, the `packageManagers` arrays in `DocsLayout`/`CenteredLayout`, so picking the Deno tab persists across widgets like the existing options do.
- Small robustness tweak: the inline `<select>` width-resizer now measures the selected option's text instead of the short package-manager name.

I verified locally with `pnpm astro check` (0 errors) and by checking the rendered tabs/commands on the get-started pages.

One thing worth flagging: the exec widget prefixes commands generically, so the "run your code" step renders `deno x tsx src/index.ts`. That works, though on Deno you can run TypeScript directly (`deno run -A src/index.ts`) without `tsx`. Happy to special-case that step if you'd prefer.

Totally fine to close this if you'd rather not add another tab. Happy to adjust anything.

_Disclosure: I work on Deno, so I have an interest here. The goal is parity with the package managers you already list, not promotion. This PR was prepared with AI assistance under human supervision: I review every change myself and personally respond to any comments or review feedback._
