### PR TITLE
docs(pg/connect-neon): remove dead driz.link/neon-cf-ex reference

### DIFF
--- a/src/content/docs/pg/connect-neon.mdx
+++ b/src/content/docs/pg/connect-neon.mdx
@@ -25,7 +25,6 @@ Querying over HTTP is faster for single, non-interactive transactions.
 If you need session or interactive transaction support, or a fully compatible drop-in replacement for the `pg` driver, you can use the WebSocket-based `neon-serverless` driver.  
 You can connect to a Neon database directly using [Postgres](/docs/get-started/postgresql-new)
   
-For an example of using Drizzle ORM with the Neon Serverless driver in a Cloudflare Worker, **[see here.](http://driz.link/neon-cf-ex)**  
 To use Neon from a serverful environment, you can use the node-postgres or Postgres.js drivers, as described in Neon's **[official Node.js docs](https://neon.tech/docs/guides/node)**
 
 #### Step 1 - Install packages


### PR DESCRIPTION
Fixes https://github.com/drizzle-team/drizzle-orm/issues/5984.

The connect-neon page linked to `http://driz.link/neon-cf-ex` for "an example of using Drizzle ORM with the Neon Serverless driver in a Cloudflare Worker". The redirect target was a removed example file, so the link 404s.

The rest of the page already covers the canonical driver install and usage (Step 1 install packages, Step 2 initialize driver), so the dead-link sentence was redundant. Removed it instead of swapping in an unrelated tutorial (no Drizzle tutorial currently targets Cloudflare Workers + Neon specifically; the closest match, the Netlify Edge Functions + Neon tutorial, is a different runtime).

`-1` line, 1 file.