### PR TITLE
fix: Add missing inline import plugin install steps

### DIFF
--- a/src/content/docs/get-started/expo-new.mdx
+++ b/src/content/docs/get-started/expo-new.mdx
@@ -77,7 +77,7 @@ const expo = SQLite.openDatabaseSync('db.db');
 const db = drizzle(expo);
 ```
 
-#### Step 4 - Create a table
+#### Step 5 - Create a table
 
 Create a `schema.ts` file in the `db` directory and declare your table:
 
@@ -92,7 +92,7 @@ export const usersTable = sqliteTable("users_table", {
 });
 ```
 
-#### Step 5 - Setup Drizzle config file
+#### Step 6 - Setup Drizzle config file
 
 **Drizzle config** - a configuration file that is used by [Drizzle Kit](/docs/kit-overview) and contains all the information about your database connection, migration folder and schema files.
 
@@ -109,7 +109,7 @@ export default defineConfig({
 });
 ```
 
-#### Step 6 - Setup `metro` config
+#### Step 7 - Setup `metro` config
 
 Create a file `metro.config.js` in root folder and add this code inside:
 
@@ -121,7 +121,15 @@ config.resolver.sourceExts.push('sql');
 module.exports = config;
 ```
 
-#### Step 7 - Update `babel` config
+#### Step 8 - Install babel plugin
+It's necessary to bundle SQL migration files as string directly to your bundle.
+
+<Npm>
+    babel-plugin-inline-import
+</Npm>
+
+#### Step 9 - Update `babel` config
+
 ```js copy filename="babel.config.js"
 module.exports = function(api) {
   api.cache(true);
@@ -132,7 +140,7 @@ module.exports = function(api) {
 };
 ```
 
-#### Step 8 - Applying changes to the database
+#### Step 10 - Applying changes to the database
 
 With Expo, you would need to generate migrations using the `drizzle-kit generate` command and then apply them at runtime using the `drizzle-orm` `migrate()` function
 
@@ -141,7 +149,7 @@ Generate migrations:
 npx drizzle-kit generate
 ```
 
-#### Step 9 - Apply migrations and query your db:
+#### Step 11 - Apply migrations and query your db:
 
 Let's **App.tsx** file with migrations and queries to create, read, update, and delete users
 
@@ -224,7 +232,7 @@ export default function App() {
 }
 ```
 
-#### Step 10 - Prebuild and run expo app
+#### Step 12 - Prebuild and run expo app
 
 <CodeTabs items={['npm', 'yarn', 'pnpm', 'bun']}>
 ```bash copy

--- a/src/content/docs/get-started/op-sqlite-new.mdx
+++ b/src/content/docs/get-started/op-sqlite-new.mdx
@@ -118,7 +118,15 @@ config.resolver.sourceExts.push('sql');
 module.exports = config;
 ```
 
-#### Step 7 - Update `babel` config
+#### Step 7 - Install babel plugin
+It's necessary to bundle SQL migration files as string directly to your bundle.
+
+<Npm>
+    babel-plugin-inline-import
+</Npm>
+
+#### Step 8 - Update `babel` config
+
 ```js copy filename="babel.config.js"
 module.exports = function(api) {
   api.cache(true);
@@ -129,7 +137,7 @@ module.exports = function(api) {
 };
 ```
 
-#### Step 8 - Applying changes to the database
+#### Step 9 - Applying changes to the database
 
 With Expo, you would need to generate migrations using the `drizzle-kit generate` command and then apply them at runtime using the `drizzle-orm` `migrate()` function
 
@@ -138,7 +146,7 @@ Generate migrations:
 npx drizzle-kit generate
 ```
 
-#### Step 9 - Apply migrations and query your db:
+#### Step 10 - Apply migrations and query your db:
 
 Let's **App.tsx** file with migrations and queries to create, read, update, and delete users
 
@@ -223,7 +231,7 @@ export default function App() {
 }
 ```
 
-#### Step 10 - Prebuild and run expo app
+#### Step 11 - Prebuild and run expo app
 
 <CodeTabs items={['npm', 'yarn', 'pnpm', 'bun']}>
 ```bash copy

--- a/src/content/docs/latest-releases/drizzle-orm-v0292.mdx
+++ b/src/content/docs/latest-releases/drizzle-orm-v0292.mdx
@@ -4,6 +4,8 @@ pubDate: 2023-12-25
 description: Implemented enhancements in the planescale relational tests. Corrected string escaping for empty PgArrays. Rectified syntax error for the exists function in SQLite. Ensured proper handling of dates in AWS Data API. Resolved the Hermes mixins constructor issue.
 ---
 
+import Npm from "@mdx/Npm.astro";
+
 ## Fixes: 
 
 - Added improvements to the planescale relational tests ([#1579](https://github.com/drizzle-team/drizzle-orm/pull/1579))
@@ -59,9 +61,9 @@ If you want to use Drizzle Migrations, you need to update babel and metro config
 
 1. Install `babel-plugin-inline-import` package.
 
-```bash copy
-npm install babel-plugin-inline-import
-```
+<Npm>
+  babel-plugin-inline-import
+</Npm>
 
 2. Update `babel.config.js` and `metro.config.js` files.
 

--- a/src/content/docs/sqlite/connect-expo-sqlite.mdx
+++ b/src/content/docs/sqlite/connect-expo-sqlite.mdx
@@ -56,9 +56,10 @@ Expo / React Native requires you to have SQL migrations bundled into the app and
 <Steps>
 #### Install babel plugin
 It's necessary to bundle SQL migration files as string directly to your bundle.
-```shell
-npm install babel-plugin-inline-import
-```
+
+<Npm>
+  babel-plugin-inline-import
+</Npm>
 
 #### Update config files.
 You will need to update `babel.config.js`, `metro.config.js` and `drizzle.config.ts` files

--- a/src/content/docs/sqlite/connect-op-sqlite.mdx
+++ b/src/content/docs/sqlite/connect-op-sqlite.mdx
@@ -32,9 +32,10 @@ OP SQLite requires you to have SQL migrations bundled into the app and we've got
 
 #### Install babel plugin
 It's necessary to bundle SQL migration files as string directly to your bundle.
-```shell
-npm install babel-plugin-inline-import
-```
+
+<Npm>
+  babel-plugin-inline-import
+</Npm>
 
 #### Update config files.
 You will need to update `babel.config.js`, `metro.config.js` and `drizzle.config.ts` files


### PR DESCRIPTION
When setting up a mobile app with Drizzle migrations, `babel.config.js` references the `inline-import` Babel plugin, but the Expo and OP-SQLite docs are missing a step to install `babel-plugin-inline-import`, despite the exact step being present in other, similiar docs.

This PR adds this missing install step to:

- `/docs/get-started/expo-new.mdx`
- `/docs/get-started/op-sqlite-new.mdx`

The added section follows the already established pattern used in:

- `/docs/sqlite/connect-expo-sqlite.mdx`
- `/docs/sqlite/connect-op-sqlite.mdx`
- `/docs/latest-releases/drizzle-orm-v0292.mdx`

Additionally, in all 5 pages, instead of hardcoding the `npm` manager, a change was made to use the `<Npm>` helper.

Before:

<img width="400" height="373" alt="Screenshot 2026-07-07 at 14 02 07" src="https://github.com/user-attachments/assets/b80dde1b-86ab-46de-9c4c-9fe410389276" />

After:

<img width="400" height="470" alt="Screenshot 2026-07-07 at 14 04 44" src="https://github.com/user-attachments/assets/1bceb2d3-e03f-4ffb-b3e2-869c36765bb9" />