### PR TITLE
docs(supabase): replace dead supabase.com/docs/guides/functions/local-development link

### DIFF
--- a/src/content/docs/tutorials/drizzle-with-supabase-edge-functions.mdx
+++ b/src/content/docs/tutorials/drizzle-with-supabase-edge-functions.mdx
@@ -73,7 +73,7 @@ It will create `supabase` folder with `config.toml` file:
     └── config.toml
 ```
 
-If you are using Visual Studio Code, follow the [Supabase documentation](https://supabase.com/docs/guides/functions/local-development#deno-with-visual-studio-code) to setup settings for Deno.
+If you are using Visual Studio Code, follow the [Supabase functions documentation](https://supabase.com/docs/guides/functions) to setup settings for Deno.
 
 #### Generate migrations
 


### PR DESCRIPTION
The Supabase docs deep link `https://supabase.com/docs/guides/functions/local-development#deno-with-visual-studio-code` referenced from the Supabase Edge Functions tutorial now returns a 404 (the page was removed in a Supabase docs restructure).

Replaces it with the parent page `/docs/guides/functions` which is reachable and still links out to the CLI `local-development` guide and the Edge Functions quickstart that cover Deno + VS Code setup.

```
HEAD https://supabase.com/docs/guides/functions/local-development  -> 404
GET  https://supabase.com/docs/guides/functions/local-development  -> 404
HEAD https://supabase.com/docs/guides/functions                   -> 200
```

Verified 2026-07-08 against the live Supabase docs.

Files changed:
- `src/content/docs/tutorials/drizzle-with-supabase-edge-functions.mdx` (line 76 — one line, link target only).