### PR TITLE
docs(tutorials): fix dead neon console /app/projects link

### DIFF
--- a/src/content/docs/tutorials/drizzle-nextjs-neon.mdx
+++ b/src/content/docs/tutorials/drizzle-nextjs-neon.mdx
@@ -50,7 +50,7 @@ If you're not using React Native, forcing the installation with `--force` or `--
 <Steps>
 #### Create a new Neon project
 
-Log in to the [Neon Console](https://console.neon.tech/app/projects) and navigate to the Projects section. Select a project or click the `New Project` button to create a new one. 
+Log in to the [Neon Console](https://console.neon.tech) and navigate to the Projects section. Select a project or click the `New Project` button to create a new one. 
 
 Your Neon projects come with a ready-to-use Postgres database named `neondb`. We'll use it in this tutorial.
 

--- a/src/content/docs/tutorials/drizzle-with-neon.mdx
+++ b/src/content/docs/tutorials/drizzle-with-neon.mdx
@@ -35,7 +35,7 @@ This tutorial demonstrates how to use Drizzle ORM with [Neon Postgres](https://n
 <Steps>
 #### Create a new Neon project
 
-Log in to the [Neon Console](https://console.neon.tech/app/projects) and navigate to the Projects section. Select a project or click the `New Project` button to create a new one. 
+Log in to the [Neon Console](https://console.neon.tech) and navigate to the Projects section. Select a project or click the `New Project` button to create a new one. 
 
 Your Neon projects come with a ready-to-use Postgres database named `neondb`. We'll use it in this tutorial.
 

--- a/src/content/docs/tutorials/drizzle-with-netlify-edge-functions-neon.mdx
+++ b/src/content/docs/tutorials/drizzle-with-netlify-edge-functions-neon.mdx
@@ -37,7 +37,7 @@ These installed packages are used only to create table in the database in [Creat
 <Steps>
 #### Setup Neon Postgres
 
-Log in to the [Neon Console](https://console.neon.tech/app/projects) and navigate to the Projects section. Select a project or click the `New Project` button to create a new one. 
+Log in to the [Neon Console](https://console.neon.tech) and navigate to the Projects section. Select a project or click the `New Project` button to create a new one. 
 
 Your Neon projects come with a ready-to-use Postgres database named `neondb`. We'll use it in this tutorial.
 


### PR DESCRIPTION
\`https://console.neon.tech/app/projects\` returns 404 — the dashboard is now served at the auth-gated root \`https://console.neon.tech\`, which redirects users to the projects list once they sign in.

Three tutorials reference the dead path with identical boilerplate ("Log in to the Neon Console and navigate to the Projects section."):

- \`src/content/docs/tutorials/drizzle-with-neon.mdx\`
- \`src/content/docs/tutorials/drizzle-nextjs-neon.mdx\`
- \`src/content/docs/tutorials/drizzle-with-netlify-edge-functions-neon.mdx\`

Replacing each with the root URL keeps the user flow identical — the root still lands on the projects dashboard after login — and matches the link used in Neon's own current setup docs.

3 files changed, 3 links updated.