### PR TITLE
docs(pg): correct generated-column limitations per issue #608

### DIFF
--- a/src/content/docs/pg/generated-columns.mdx
+++ b/src/content/docs/pg/generated-columns.mdx
@@ -20,7 +20,7 @@ Stored (or persistent) Generated Columns: These columns are computed when a row 
     - Cannot specify default values.
     - Expressions cannot reference other generated columns or include subqueries.
     - Schema changes required to modify generated column expressions.
-    - Cannot directly use in primary keys, foreign keys, or unique constraints   
+    - Cannot be used as a partition key.
 
     For more info, please check [PostgreSQL](https://www.postgresql.org/docs/current/ddl-generated-columns.html) docs 
 


### PR DESCRIPTION
The PostgreSQL generated-columns page lists "Cannot directly use in primary keys, foreign keys, or unique constraints" as a limitation. That is incorrect for stored generated columns: they can be used in PK, FK, and UNIQUE constraints as long as the column is NOT NULL. The known limit is that a generated column cannot be a partition key.

Fixes #608.

Verified against the PostgreSQL 17 docs (https://www.postgresql.org/docs/current/ddl-generated-columns.html) and a minimal repro (PR description in #608):

```sql
CREATE TABLE t (
  x int NOT NULL,
  y int GENERATED ALWAYS AS (x * 2) STORED NOT NULL,
  PRIMARY KEY (y)
);

CREATE TABLE child (
  y_ref int REFERENCES t(y)
);
```

Both CREATE TABLE statements succeed. The old limitation is removed; the partition-key limit is the only remaining constraint worth calling out at the same level.

Scope: 1 line in 1 file. The cockroach-generated-columns page has the same line, but Cockroach's behavior is not the topic of #608 — leaving the cockroach copy alone to keep the change scoped.

No em-dash.