### PR TITLE
Add /.well-known/security.txt (RFC 9116)

### DIFF
--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,5 @@
+Contact: mailto:security@drizzle.team
+Policy: https://github.com/drizzle-team/drizzle-orm/blob/main/SECURITY.md
+Preferred-Languages: en
+Canonical: https://orm.drizzle.team/.well-known/security.txt
+Expires: 2027-01-01T00:00:00.000Z


### PR DESCRIPTION
Hi, and thank you for Drizzle.

This adds a machine-readable `/.well-known/security.txt` (RFC 9116) to the docs site's `public/` dir, so it serves at `https://orm.drizzle.team/.well-known/security.txt` (currently 404). It just points automated tooling at the reporting channel `SECURITY.md` already documents:

```
Contact: mailto:security@drizzle.team
Policy: https://github.com/drizzle-team/drizzle-orm/blob/main/SECURITY.md
Preferred-Languages: en
Canonical: https://orm.drizzle.team/.well-known/security.txt
Expires: 2027-01-01T00:00:00.000Z
```

I verified the `public/` passthrough serves at the site root (e.g. `orm.drizzle.team/favicon.ico` returns 200), so this file will be served at the well-known path. RFC 9116 recommends refreshing `Expires` at least annually — feel free to adjust the date or values.

For transparency: I used AI assistance to help identify this and draft the file; I verified the live 404, the serving passthrough, and the SECURITY.md channel myself.
