### PR TITLE
Fix unclosed table call in SingleStore schema examples

### DIFF
--- a/src/content/docs/singlestore/drizzle-kit-generate.mdx
+++ b/src/content/docs/singlestore/drizzle-kit-generate.mdx
@@ -38,7 +38,7 @@ export const users = p.singlestoreTable("users", {
   id: p.int().primaryKey().autoincrement(),
   name: p.varchar({ length: 255 }),
   email: p.varchar({ length: 255 }).unique(), 
-};
+});
 ```
 ```                                  
 ┌────────────────────────┐                  

--- a/src/content/docs/singlestore/drizzle-kit-pull.mdx
+++ b/src/content/docs/singlestore/drizzle-kit-pull.mdx
@@ -49,7 +49,7 @@ export const users = p.singlestoreTable("users", {
   id: p.int().primaryKey().autoincrement(),
   name: p.varchar({ length: 255 }),
   email: p.varchar({ length: 255 }).unique(), 
-};
+});
 ```
 </Section>
 </Callout>

--- a/src/content/docs/singlestore/drizzle-kit-push.mdx
+++ b/src/content/docs/singlestore/drizzle-kit-push.mdx
@@ -40,7 +40,7 @@ import * as p from "drizzle-orm/singlestore-core";
 export const users = p.singlestoreTable("users", {
   id: p.int().primaryKey().autoincrement(),
   name: p.varchar({ length: 255 }),
-};
+});
 ```
 ```
 ┌─────────────────────┐                  


### PR DESCRIPTION
The SingleStore schema example closes `singlestoreTable(...)` with `};` instead of `});`, so the call is never closed. It appears in three files:

- `singlestore/drizzle-kit-generate.mdx:41`
- `singlestore/drizzle-kit-push.mdx:43`
- `singlestore/drizzle-kit-pull.mdx:52`

```diff
 export const users = p.singlestoreTable("users", {
   id: p.int().primaryKey().autoincrement(),
   name: p.varchar({ length: 255 }),
   email: p.varchar({ length: 255 }).unique(),
-};
+});
```

The MySQL versions of the same three pages have the identical snippet with `});` at the same line, so this looks like it was missed when the SingleStore pages were derived from them.
