### PR TITLE
Pin remaining drizzle-kit and drizzle-seed install commands to @rc

### DIFF
--- a/src/content/docs/cockroach/kit-overview.mdx
+++ b/src/content/docs/cockroach/kit-overview.mdx
@@ -20,7 +20,7 @@ import Prerequisites from "@mdx/Prerequisites.astro"
 
 **Drizzle Kit** is a CLI tool for managing SQL database migrations with Drizzle.
 <Npm>
-  -D drizzle-kit
+  -D drizzle-kit@rc
 </Npm>
 <Callout type="warning">
 Make sure to first go through Drizzle [get started](/docs/cockroach/get-started) and [migration fundamentals](/docs/cockroach/migrations) and pick SQL migration flow that suits your business needs best. 

--- a/src/content/docs/cockroach/seed-overview.mdx
+++ b/src/content/docs/cockroach/seed-overview.mdx
@@ -33,7 +33,7 @@ With drizzle-seed, you get the best of both worlds: the ability to generate real
 
 ## Installation
 
-<Npm>drizzle-seed</Npm>
+<Npm>drizzle-seed@rc</Npm>
 
 ## Basic Usage
 

--- a/src/content/docs/mssql/kit-overview.mdx
+++ b/src/content/docs/mssql/kit-overview.mdx
@@ -20,7 +20,7 @@ import Prerequisites from "@mdx/Prerequisites.astro"
 
 **Drizzle Kit** is a CLI tool for managing SQL database migrations with Drizzle.
 <Npm>
-  -D drizzle-kit
+  -D drizzle-kit@rc
 </Npm>
 <Callout type="warning">
 Make sure to first go through Drizzle [get started](/docs/mssql/get-started) and [migration fundamentals](/docs/mssql/migrations) and pick SQL migration flow that suits your business needs best. 

--- a/src/content/docs/mssql/seed-overview.mdx
+++ b/src/content/docs/mssql/seed-overview.mdx
@@ -35,7 +35,7 @@ With drizzle-seed, you get the best of both worlds: the ability to generate real
 
 ## Installation
 
-<Npm>drizzle-seed</Npm>
+<Npm>drizzle-seed@rc</Npm>
 
 ## Basic Usage
 

--- a/src/content/docs/mysql/kit-overview.mdx
+++ b/src/content/docs/mysql/kit-overview.mdx
@@ -20,7 +20,7 @@ import Prerequisites from "@mdx/Prerequisites.astro"
 
 **Drizzle Kit** is a CLI tool for managing SQL database migrations with Drizzle.
 <Npm>
-  -D drizzle-kit
+  -D drizzle-kit@rc
 </Npm>
 <Callout type="warning">
 Make sure to first go through Drizzle [get started](/docs/mysql/get-started) and [migration fundamentals](/docs/mysql/migrations) and pick SQL migration flow that suits your business needs best. 

--- a/src/content/docs/mysql/seed-overview.mdx
+++ b/src/content/docs/mysql/seed-overview.mdx
@@ -35,7 +35,7 @@ With drizzle-seed, you get the best of both worlds: the ability to generate real
 
 ## Installation
 
-<Npm>drizzle-seed</Npm>
+<Npm>drizzle-seed@rc</Npm>
 
 ## Basic Usage
 

--- a/src/content/docs/pg/kit-overview.mdx
+++ b/src/content/docs/pg/kit-overview.mdx
@@ -20,7 +20,7 @@ import Prerequisites from "@mdx/Prerequisites.astro"
 
 **Drizzle Kit** is a CLI tool for managing SQL database migrations with Drizzle.
 <Npm>
-  -D drizzle-kit
+  -D drizzle-kit@rc
 </Npm>
 <Callout type="warning">
 Make sure to first go through Drizzle [get started](/docs/get-started) and [migration fundamentals](/docs/migrations) and pick SQL migration flow that suits your business needs best. 

--- a/src/content/docs/pg/seed-overview.mdx
+++ b/src/content/docs/pg/seed-overview.mdx
@@ -35,7 +35,7 @@ With drizzle-seed, you get the best of both worlds: the ability to generate real
 
 ## Installation
 
-<Npm>drizzle-seed</Npm>
+<Npm>drizzle-seed@rc</Npm>
 
 ## Basic Usage
 

--- a/src/content/docs/singlestore/kit-overview.mdx
+++ b/src/content/docs/singlestore/kit-overview.mdx
@@ -20,7 +20,7 @@ import Prerequisites from "@mdx/Prerequisites.astro"
 
 **Drizzle Kit** is a CLI tool for managing SQL database migrations with Drizzle.
 <Npm>
-  -D drizzle-kit
+  -D drizzle-kit@rc
 </Npm>
 <Callout type="warning">
 Make sure to first go through Drizzle [get started](/docs/singlestore/get-started) and [migration fundamentals](/docs/singlestore/migrations) and pick SQL migration flow that suits your business needs best. 

--- a/src/content/docs/singlestore/seed-overview.mdx
+++ b/src/content/docs/singlestore/seed-overview.mdx
@@ -35,7 +35,7 @@ With drizzle-seed, you get the best of both worlds: the ability to generate real
 
 ## Installation
 
-<Npm>drizzle-seed</Npm>
+<Npm>drizzle-seed@rc</Npm>
 
 ## Basic Usage
 

--- a/src/content/docs/sqlite/kit-overview.mdx
+++ b/src/content/docs/sqlite/kit-overview.mdx
@@ -20,7 +20,7 @@ import Prerequisites from "@mdx/Prerequisites.astro"
 
 **Drizzle Kit** is a CLI tool for managing SQL database migrations with Drizzle.
 <Npm>
-  -D drizzle-kit
+  -D drizzle-kit@rc
 </Npm>
 <Callout type="warning">
 Make sure to first go through Drizzle [get started](/docs/sqlite/get-started) and [migration fundamentals](/docs/sqlite/migrations) and pick SQL migration flow that suits your business needs best. 

--- a/src/content/docs/sqlite/seed-overview.mdx
+++ b/src/content/docs/sqlite/seed-overview.mdx
@@ -35,7 +35,7 @@ With drizzle-seed, you get the best of both worlds: the ability to generate real
 
 ## Installation
 
-<Npm>drizzle-seed</Npm>
+<Npm>drizzle-seed@rc</Npm>
 
 ## Basic Usage
 


### PR DESCRIPTION
## Summary

Pins the remaining untagged install commands to the `@rc` dist-tag for the 1.0 release-candidate window: `-D drizzle-kit` -> `-D drizzle-kit@rc` in the six `kit-overview.mdx` pages, and `drizzle-seed` -> `drizzle-seed@rc` in the six `seed-overview.mdx` pages (one dialect each: cockroach, mssql, mysql, pg, singlestore, sqlite). Everything else on `main` was already `@rc`-pinned.

## Flags for maintainers

- **Validator companions have no `rc` tag.** `drizzle-zod`, `drizzle-valibot`, `drizzle-typebox`, `drizzle-arktype` currently have no `rc` dist-tag published (their newest v1-line snapshot is a `1.0.0-beta.14` prerelease), so their install commands were deliberately left untagged in this PR. Publishing `rc` tags for these packages would let a follow-up sweep pin them too.
- **`graphql.mdx` pairing left as-is.** That page pins `drizzle-orm@latest` next to `drizzle-graphql` (latest `0.8.5`, no `rc` tag, v1 compatibility with `drizzle-graphql` is unknown). Left untouched on purpose rather than guessing at a pairing that might not work.
- **No `llms.txt` change needed.** It's generated from the content collection at build time (`src/pages/llms.txt.ts`), so it picks up these fixes automatically once this merges and deploys.

## Test plan

- [x] `git grep -n '<Npm>drizzle-seed</Npm>' -- src/content` returns nothing
- [x] `git grep -nE '^  -D drizzle-kit$' -- src/content` returns nothing
- [x] `git grep -nE 'drizzle-(kit|orm|seed)@beta' -- src/content ':!*latest-releases*'` returns nothing
- [x] `git diff origin/main --stat` touches only the 12 intended files