### PR TITLE
docs: cross-link the three Supabase pages

### DIFF
--- a/src/content/docs/get-started/supabase-new.mdx
+++ b/src/content/docs/get-started/supabase-new.mdx
@@ -27,6 +27,10 @@ import SetupEnv from '@mdx/get-started/SetupEnv.mdx';
   - **Supabase** - open source Firebase alternative - [read here](https://supabase.com/)
 </Prerequisites>
 
+<Callout title='other Supabase docs'>
+This guide sets up a new project from scratch. For connection options and pooling, see [Drizzle \<\> Supabase](/docs/connect-supabase). For a walkthrough that covers migrations, Row Level Security and querying, see the [Supabase tutorial](/docs/tutorials/drizzle-with-supabase).
+</Callout>
+
 <FileStructure/>
 
 #### Step 1 - Install **postgres** package

--- a/src/content/docs/pg/connect-supabase.mdx
+++ b/src/content/docs/pg/connect-supabase.mdx
@@ -18,6 +18,10 @@ According to the **[official website](https://supabase.com/docs)**, Supabase is 
 
 Checkout official **[Supabase + Drizzle](https://supabase.com/docs/guides/database/drizzle)** docs.
 
+<Callout title='other Supabase docs'>
+This page covers connecting Drizzle to Supabase. To set up a new project step by step, see [Get Started with Drizzle and Supabase](/docs/get-started/supabase-new). For a walkthrough that covers migrations, Row Level Security and querying, see the [Supabase tutorial](/docs/tutorials/drizzle-with-supabase).
+</Callout>
+
 #### Step 1 - Install packages
 
 <Npm>

--- a/src/content/docs/tutorials/drizzle-with-supabase.mdx
+++ b/src/content/docs/tutorials/drizzle-with-supabase.mdx
@@ -12,6 +12,10 @@ import Callout from '@mdx/Callout.astro';
 
 This tutorial demonstrates how to use Drizzle ORM with [Supabase Database](https://supabase.com/docs/guides/database/overview). Every Supabase project comes with a full [Postgres](https://www.postgresql.org/docs) database.
 
+<Callout title='other Supabase docs'>
+This tutorial is the most complete of the three Supabase pages. For a shorter setup guide, see [Get Started with Drizzle and Supabase](/docs/get-started/supabase-new). For connection options and pooling, see [Drizzle \<\> Supabase](/docs/connect-supabase).
+</Callout>
+
 <Prerequisites>
 - You should have installed Drizzle ORM and [Drizzle kit](/docs/kit-overview). You can do this by running the following command:
 <Npm>


### PR DESCRIPTION
Closes #4949

### Problem

Supabase is covered on three pages:

- [Get Started with Drizzle and Supabase](https://orm.drizzle.team/docs/get-started/supabase-new)
- [Drizzle \<\> Supabase](https://orm.drizzle.team/docs/connect-supabase)
- [Drizzle with Supabase Database](https://orm.drizzle.team/docs/tutorials/drizzle-with-supabase)

None of them link to the other two, so as #4949 puts it, you end up reading all three to be sure one doesn't contain something the others don't.

### Approach

The three pages aren't really duplicates — they serve different purposes (quickstart / connection reference / full tutorial), and the same split exists for the other providers. So rather than merging them, this PR makes the split visible: each page gets a short callout explaining what it covers and linking to the other two.

This keeps existing URLs intact and follows the `<Callout>` pattern already used elsewhere in the docs.

### Changes

Three files, +12 lines, no deletions:

| File | Callout says |
|---|---|
| `get-started/supabase-new.mdx` | sets up a new project → connection page, tutorial |
| `pg/connect-supabase.mdx` | covers connecting → get started, tutorial |
| `tutorials/drizzle-with-supabase.mdx` | most complete → get started, connection page |

### Verification

- `pnpm test` — 29/29 passing
- `pnpm build` (`astro check && astro build`) — clean, 769 pages built
- Confirmed in the built HTML that each callout renders and links only to the other two pages

Happy to adjust the wording, or to close this if you'd rather consolidate the pages instead.