### PR TITLE
docs: fix spread order in defineRelationsPart Rule 1 example

### DIFF
--- a/src/content/docs/mysql/relations.mdx
+++ b/src/content/docs/mysql/relations.mdx
@@ -538,7 +538,7 @@ Having `{ ...relations, ...part }` will result in
 }
 ```
 
-and having `{ ...relations, ...part }` will result in
+and having `{ ...part, ...relations }` will result in
 ```json
 {
   "users": {"invitee": {...}, "posts": {...}},

--- a/src/content/docs/pg/relations.mdx
+++ b/src/content/docs/pg/relations.mdx
@@ -528,7 +528,7 @@ Having `{ ...relations, ...part }` will result in
 }
 ```
 
-and having `{ ...relations, ...part }` will result in
+and having `{ ...part, ...relations }` will result in
 ```json
 {
   "users": {"invitee": {...}, "posts": {...}},

--- a/src/content/docs/sqlite/relations.mdx
+++ b/src/content/docs/sqlite/relations.mdx
@@ -528,7 +528,7 @@ Having `{ ...relations, ...part }` will result in
 }
 ```
 
-and having `{ ...relations, ...part }` will result in
+and having `{ ...part, ...relations }` will result in
 ```json
 {
   "users": {"invitee": {...}, "posts": {...}},


### PR DESCRIPTION
Closes #629

### Problem

In the **Rule 1** warning for `defineRelationsPart`, the collapsed "Why it's important?" callout compares two spread orders — but both sentences say the same thing:

> Having `{ ...relations, ...part }` will result in […]
>
> and having `{ ...relations, ...part }` will result in […]

The second block shows the outcome of the *opposite* order — `posts: {}`, with the comment "posts relations information will be lost" — because the empty placeholder from `relations` overwrites what `part` defined. As written, the reader can't see which order causes that.

The code sample directly above already labels the orders correctly, so only the prose is wrong.

### Change

Second sentence becomes `{ ...part, ...relations }`. One line per dialect:

- `src/content/docs/pg/relations.mdx`
- `src/content/docs/mysql/relations.mdx`
- `src/content/docs/sqlite/relations.mdx`

The issue mentions one page; the same paragraph is duplicated across these three, so all three are updated. `cockroach`, `mssql` and `singlestore` don't contain this passage.

### Verification

- `pnpm test` — 29/29 passing
- `pnpm build` (`astro check && astro build`) — clean, 769 pages
- Checked the built HTML for all three dialects: each now renders one `{ ...relations, ...part }` and one `{ ...part, ...relations }`, and the "correct order" sentence above is unchanged