### PR TITLE
docs: update spelling and indentation mistakes

### DIFF
--- a/src/content/docs/cockroach/relations.mdx
+++ b/src/content/docs/cockroach/relations.mdx
@@ -84,7 +84,7 @@ export const usersRelations = relations(users, ({ one }) => ({
 }));
 ```
 
-Another example would be a user having a profile information stored in separate table. In this case, because the foreign key is stored in the "profile_info" table, the user relation have neither fields or references. This tells Typescript that `user.profileInfo` is nullable:
+Another example would be a user having profile information stored in separate table. In this case, because the foreign key is stored in the "profile_info" table, the user relation have neither fields or references. This tells Typescript that `user.profileInfo` is nullable:
 
 ```typescript copy {9-17}
 import { cockroachTable, int4, text, jsonb } from 'drizzle-orm/cockroach-core';

--- a/src/content/docs/mssql/relations.mdx
+++ b/src/content/docs/mssql/relations.mdx
@@ -84,7 +84,7 @@ export const usersRelations = relations(users, ({ one }) => ({
 }));
 ```
 
-Another example would be a user having a profile information stored in separate table. In this case, because the foreign key is stored in the "profile_info" table, the user relation have neither fields or references. This tells Typescript that `user.profileInfo` is nullable:
+Another example would be a user having profile information stored in separate table. In this case, because the foreign key is stored in the "profile_info" table, the user relation have neither fields or references. This tells Typescript that `user.profileInfo` is nullable:
 
 ```typescript copy {9-17}
 import { mssqlTable, ntext, int } from 'drizzle-orm/mssql-core';

--- a/src/content/docs/mysql/relations.mdx
+++ b/src/content/docs/mysql/relations.mdx
@@ -481,7 +481,7 @@ const db = drizzle(process.env.DB_URL, { relations: { ...relations, ...part } })
 <Callout type='warning'>
 There are a few rules you would need to follow to make sure it `defineRelationsParts` works as expected
 
-**Rule 1**: If you specify relations with parts, when passing it to drizzle db function you would need to specify it in the right order(main relations goes first)
+**Rule 1**: If you specify reltions with parts, when passing it to drizzle db function you would need to specify it in the right order(main relations goes first)
 ```ts
 // ✅
 const db = drizzle(process.env.DB_URL, { relations: { ...relations, ...part } })
@@ -549,7 +549,7 @@ and having `{ ...relations, ...part }` will result in
 
 </Callout>
 
-**Rule 2**: You should have min relations, so drizzle can infer all of the table for autocomplete. If you want to have only parts, then 
+**Rule 2**: You should have main relations, so drizzle can infer all of the table for autocomplete. If you want to have only parts, then 
 one of your parts should be empty, like this:
 
 ```ts

--- a/src/content/docs/mysql/relations.mdx
+++ b/src/content/docs/mysql/relations.mdx
@@ -189,7 +189,7 @@ export const relations = defineRelations({ users }, (r) => ({
 }));
 ```
 
-Another example would be a user having a profile information stored in separate table. In this case, because the foreign key is stored in the "profile_info" table, the user relation have neither fields or references. This tells Typescript that `user.profileInfo` is nullable:
+Another example would be a user having profile information stored in separate table. In this case, because the foreign key is stored in the "profile_info" table, the user relation have neither fields or references. This tells Typescript that `user.profileInfo` is nullable:
 
 ```typescript copy {15-22}
 import { mysqlTable, text, int, json } from 'drizzle-orm/mysql-core';

--- a/src/content/docs/mysql/relations.mdx
+++ b/src/content/docs/mysql/relations.mdx
@@ -481,7 +481,7 @@ const db = drizzle(process.env.DB_URL, { relations: { ...relations, ...part } })
 <Callout type='warning'>
 There are a few rules you would need to follow to make sure it `defineRelationsParts` works as expected
 
-**Rule 1**: If you specify reltions with parts, when passing it to drizzle db function you would need to specify it in the right order(main relations goes first)
+**Rule 1**: If you specify relations with parts, when passing it to drizzle db function you would need to specify it in the right order(main relations goes first)
 ```ts
 // ✅
 const db = drizzle(process.env.DB_URL, { relations: { ...relations, ...part } })

--- a/src/content/docs/pg/relations.mdx
+++ b/src/content/docs/pg/relations.mdx
@@ -471,7 +471,7 @@ const db = drizzle(process.env.DB_URL, { relations: { ...relations, ...part } })
 <Callout type='warning'>
 There are a few rules you would need to follow to make sure it `defineRelationsParts` works as expected
 
-**Rule 1**: If you specify relations with parts, when passing it to drizzle db function you would need to specify it in the right order(main relations goes first)
+**Rule 1**: If you specify reltions with parts, when passing it to drizzle db function you would need to specify it in the right order(main relations goes first)
 ```ts
 // ✅
 const db = drizzle(process.env.DB_URL, { relations: { ...relations, ...part } })
@@ -539,7 +539,7 @@ and having `{ ...relations, ...part }` will result in
 
 </Callout>
 
-**Rule 2**: You should have min relations, so drizzle can infer all of the table for autocomplete. If you want to have only parts, then 
+**Rule 2**: You should have main relations, so drizzle can infer all of the table for autocomplete. If you want to have only parts, then 
 one of your parts should be empty, like this:
 
 ```ts

--- a/src/content/docs/pg/relations.mdx
+++ b/src/content/docs/pg/relations.mdx
@@ -179,7 +179,7 @@ export const relations = defineRelations({ users }, (r) => ({
 }));
 ```
 
-Another example would be a user having a profile information stored in separate table. In this case, because the foreign key is stored in the "profile_info" table, the user relation have neither fields or references. This tells Typescript that `user.profileInfo` is nullable:
+Another example would be a user having profile information stored in separate table. In this case, because the foreign key is stored in the "profile_info" table, the user relation have neither fields or references. This tells Typescript that `user.profileInfo` is nullable:
 
 ```typescript copy {15-22}
 import { pgTable, serial, text, integer, jsonb } from 'drizzle-orm/pg-core';

--- a/src/content/docs/pg/relations.mdx
+++ b/src/content/docs/pg/relations.mdx
@@ -471,7 +471,7 @@ const db = drizzle(process.env.DB_URL, { relations: { ...relations, ...part } })
 <Callout type='warning'>
 There are a few rules you would need to follow to make sure it `defineRelationsParts` works as expected
 
-**Rule 1**: If you specify reltions with parts, when passing it to drizzle db function you would need to specify it in the right order(main relations goes first)
+**Rule 1**: If you specify relations with parts, when passing it to drizzle db function you would need to specify it in the right order(main relations goes first)
 ```ts
 // ✅
 const db = drizzle(process.env.DB_URL, { relations: { ...relations, ...part } })

--- a/src/content/docs/pg/rqb.mdx
+++ b/src/content/docs/pg/rqb.mdx
@@ -83,71 +83,71 @@ await db.query.users.findMany({
 	`drizzle` import path depends on the **[database driver](/docs/connect-overview)** you're using.
 </Callout>
 <CodeTabs items={["index.ts", "schema.ts", "relations.ts"]}>
-	<CodeTab>
-	```typescript copy
-	import { relations } from "./relations";
-	import { drizzle } from "drizzle-orm/...";
+<CodeTab>
+```typescript copy
+import { relations } from "./relations";
+import { drizzle } from "drizzle-orm/...";
 
-	const db = drizzle(process.env.DATABASE_URL, { relations });
+const db = drizzle(process.env.DATABASE_URL, { relations });
 
-	const result = await db.query.users.findMany({
-	  with: {
-	    posts: true,
-	  },
-	});
-	```
+const result = await db.query.users.findMany({
+  with: {
+    posts: true,
+  },
+});
+```
 
-	```ts
-	[{
-		id: 10,
-		name: "Dan",
-		posts: [
-			{
-				id: 1,
-				content: "SQL is awesome",
-				authorId: 10,
-			},
-			{
-				id: 2,
-				content: "But check relational queries",
-				authorId: 10,
-			}
-		]
-	}]
-	```
-	</CodeTab>
+```ts
+[{
+  id: 10,
+  name: "Dan",
+  posts: [
+    {
+      id: 1,
+      content: "SQL is awesome",
+      authorId: 10,
+    },
+    {
+      id: 2,
+      content: "But check relational queries",
+      authorId: 10,
+    }
+  ]
+}]
+```
+</CodeTab>
 
-		```typescript copy
-    import * as p from "drizzle-orm/pg-core";
-    
-    export const posts = p.pgTable("posts", {
-      id: p.integer().primaryKey(),
-      content: p.text().notNull(),
-      authorId: p.integer("author_id").notNull(),
-    });
-    
-    export const users = p.pgTable("users", {
-      id: p.integer().primaryKey(),
-      name: p.text().notNull(),
-    });
-	```
+```typescript copy
+import * as p from "drizzle-orm/pg-core";
 
-	```typescript copy
-	import { defineRelations } from "drizzle-orm";
-	import { posts, users } from "./schema";
+export const posts = p.pgTable("posts", {
+  id: p.integer().primaryKey(),
+  content: p.text().notNull(),
+  authorId: p.integer("author_id").notNull(),
+});
 
-	export const relations = defineRelations({ users, posts }, (r) => ({
-      posts: {
-        author: r.one.users({
-          from: r.posts.authorId,
-          to: r.users.id,
-        }),
-      },
-      users: {
-        posts: r.many.posts(),
-      },
-    }));
-	```
+export const users = p.pgTable("users", {
+  id: p.integer().primaryKey(),
+  name: p.text().notNull(),
+});
+```
+
+```typescript copy
+import { defineRelations } from "drizzle-orm";
+import { posts, users } from "./schema";
+
+export const relations = defineRelations({ users, posts }, (r) => ({
+    posts: {
+      author: r.one.users({
+        from: r.posts.authorId,
+        to: r.users.id,
+      }),
+    },
+    users: {
+      posts: r.many.posts(),
+    },
+  }));
+```
 </CodeTabs>
 
 Relational queries are an extension to Drizzle's original **[query builder](/docs/select)**.

--- a/src/content/docs/relations.mdx
+++ b/src/content/docs/relations.mdx
@@ -84,7 +84,7 @@ export const usersRelations = relations(users, ({ one }) => ({
 }));
 ```
 
-Another example would be a user having a profile information stored in separate table. In this case, because the foreign key is stored in the "profile_info" table, the user relation have neither fields or references. This tells Typescript that `user.profileInfo` is nullable:
+Another example would be a user having profile information stored in separate table. In this case, because the foreign key is stored in the "profile_info" table, the user relation have neither fields or references. This tells Typescript that `user.profileInfo` is nullable:
 
 ```typescript copy {9-17}
 import { pgTable, serial, text, integer, jsonb } from 'drizzle-orm/pg-core';

--- a/src/content/docs/singlestore/relations-v2.mdx
+++ b/src/content/docs/singlestore/relations-v2.mdx
@@ -470,7 +470,7 @@ const db = drizzle(process.env.DB_URL, { relations: { ...relations, ...part } })
 <Callout type='warning'>
 There are a few rules you would need to follow to make sure it `defineRelationsParts` works as expected
 
-**Rule 1**: If you specify relations with parts, when passing it to drizzle db function you would need to specify it in the right order(main relations goes first)
+**Rule 1**: If you specify reltions with parts, when passing it to drizzle db function you would need to specify it in the right order(main relations goes first)
 ```ts
 // ✅
 const db = drizzle(process.env.DB_URL, { relations: { ...relations, ...part } })
@@ -538,7 +538,7 @@ and having `{ ...relations, ...part }` will result in
 
 </Callout>
 
-**Rule 2**: You should have min relations, so drizzle can infer all of the table for autocomplete. If you want to have only parts, then 
+**Rule 2**: You should have main relations, so drizzle can infer all of the table for autocomplete. If you want to have only parts, then 
 one of your parts should be empty, like this:
 
 ```ts

--- a/src/content/docs/singlestore/relations-v2.mdx
+++ b/src/content/docs/singlestore/relations-v2.mdx
@@ -178,7 +178,7 @@ export const relations = defineRelations({ users }, (r) => ({
 }));
 ```
 
-Another example would be a user having a profile information stored in separate table. In this case, because the foreign key is stored in the "profile_info" table, the user relation have neither fields or references. This tells Typescript that `user.profileInfo` is nullable:
+Another example would be a user having profile information stored in separate table. In this case, because the foreign key is stored in the "profile_info" table, the user relation have neither fields or references. This tells Typescript that `user.profileInfo` is nullable:
 
 ```typescript copy {15-22}
 import { pgTable, serial, text, integer, jsonb } from 'drizzle-orm/pg-core';

--- a/src/content/docs/singlestore/relations-v2.mdx
+++ b/src/content/docs/singlestore/relations-v2.mdx
@@ -470,7 +470,7 @@ const db = drizzle(process.env.DB_URL, { relations: { ...relations, ...part } })
 <Callout type='warning'>
 There are a few rules you would need to follow to make sure it `defineRelationsParts` works as expected
 
-**Rule 1**: If you specify reltions with parts, when passing it to drizzle db function you would need to specify it in the right order(main relations goes first)
+**Rule 1**: If you specify relations with parts, when passing it to drizzle db function you would need to specify it in the right order(main relations goes first)
 ```ts
 // ✅
 const db = drizzle(process.env.DB_URL, { relations: { ...relations, ...part } })

--- a/src/content/docs/sqlite/relations.mdx
+++ b/src/content/docs/sqlite/relations.mdx
@@ -471,7 +471,7 @@ const db = drizzle(process.env.DB_URL, { relations: { ...relations, ...part } })
 <Callout type='warning'>
 There are a few rules you would need to follow to make sure it `defineRelationsParts` works as expected
 
-**Rule 1**: If you specify relations with parts, when passing it to drizzle db function you would need to specify it in the right order(main relations goes first)
+**Rule 1**: If you specify reltions with parts, when passing it to drizzle db function you would need to specify it in the right order(main relations goes first)
 ```ts
 // ✅
 const db = drizzle(process.env.DB_URL, { relations: { ...relations, ...part } })
@@ -539,7 +539,7 @@ and having `{ ...relations, ...part }` will result in
 
 </Callout>
 
-**Rule 2**: You should have min relations, so drizzle can infer all of the table for autocomplete. If you want to have only parts, then 
+**Rule 2**: You should have main relations, so drizzle can infer all of the table for autocomplete. If you want to have only parts, then 
 one of your parts should be empty, like this:
 
 ```ts

--- a/src/content/docs/sqlite/relations.mdx
+++ b/src/content/docs/sqlite/relations.mdx
@@ -179,7 +179,7 @@ export const relations = defineRelations({ users }, (r) => ({
 }));
 ```
 
-Another example would be a user having a profile information stored in separate table. In this case, because the foreign key is stored in the "profile_info" table, the user relation have neither fields or references. This tells Typescript that `user.profileInfo` is nullable:
+Another example would be a user having profile information stored in separate table. In this case, because the foreign key is stored in the "profile_info" table, the user relation have neither fields or references. This tells Typescript that `user.profileInfo` is nullable:
 
 ```typescript copy {15-22}
 import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';

--- a/src/content/docs/sqlite/relations.mdx
+++ b/src/content/docs/sqlite/relations.mdx
@@ -471,7 +471,7 @@ const db = drizzle(process.env.DB_URL, { relations: { ...relations, ...part } })
 <Callout type='warning'>
 There are a few rules you would need to follow to make sure it `defineRelationsParts` works as expected
 
-**Rule 1**: If you specify reltions with parts, when passing it to drizzle db function you would need to specify it in the right order(main relations goes first)
+**Rule 1**: If you specify relations with parts, when passing it to drizzle db function you would need to specify it in the right order(main relations goes first)
 ```ts
 // ✅
 const db = drizzle(process.env.DB_URL, { relations: { ...relations, ...part } })


### PR DESCRIPTION
- Polished docs wording across relations guides to improve grammar in profile information examples.
- Fixed typo in Rule 1 guidance (`reltions` -> `relations`) in multi-part relations sections.
- Updated Rule 2 wording from `min relations` to `main relations` across dialect docs for consistency.
- Cleaned indentation in the Postgres RQB `schema.ts` code tab to improve readability.
- Scope is documentation-only; no runtime or API behavior changes.