### PR TITLE
Document Cloudflare KV query caching

### DIFF
--- a/src/content/docs/cockroach/cache.mdx
+++ b/src/content/docs/cockroach/cache.mdx
@@ -46,6 +46,51 @@ const db = drizzle(process.env.DB_URL!, {
 });
 ```
 
+### Cloudflare KV integration
+
+Cloudflare Workers applications can use a bound [Workers KV](https://developers.cloudflare.com/kv/) namespace as the query cache:
+
+```jsonc
+// wrangler.jsonc
+{
+  "kv_namespaces": [
+    {
+      "binding": "QUERY_CACHE",
+      "id": "<YOUR_KV_NAMESPACE_ID>"
+    }
+  ]
+}
+```
+
+Pass the binding to `cloudflareKVCache()` when creating your Drizzle instance:
+
+```ts
+import { cloudflareKVCache } from "drizzle-orm/cache/cloudflare-kv";
+import { drizzle } from "drizzle-orm/...";
+
+const db = drizzle(env.DB, {
+  cache: cloudflareKVCache(env.QUERY_CACHE, {
+    strategy: "explicit",
+    prefix: "drizzle",
+    config: { ex: 300 }
+  })
+});
+```
+
+Set `strategy: "all"` to cache every select query. Per-query settings passed to `.$withCache()` override the default expiration:
+
+```ts
+const users = await db.select().from(usersTable).$withCache({
+  config: { ex: 600 }
+});
+```
+
+The adapter supports `ex`, `px`, `exat`, and `pxat`. Cloudflare KV requires expiration targets to be at least 60 seconds in the future, so shorter values throw an error. The Redis-specific `keepTtl` and `hexOptions` settings are not supported.
+
+<Callout type="warning">
+Workers KV is eventually consistent and is intended for read-heavy data that can tolerate stale results. Table and tag invalidation can take time to become visible in other Cloudflare locations. Use a strongly consistent store when read-after-write consistency is required.
+</Callout>
+
 ## Cache config reference
 
 Drizzle supports the following cache config options for Upstash:

--- a/src/content/docs/mssql/cache.mdx
+++ b/src/content/docs/mssql/cache.mdx
@@ -46,6 +46,51 @@ const db = drizzle(process.env.DB_URL!, {
 });
 ```
 
+### Cloudflare KV integration
+
+Cloudflare Workers applications can use a bound [Workers KV](https://developers.cloudflare.com/kv/) namespace as the query cache:
+
+```jsonc
+// wrangler.jsonc
+{
+  "kv_namespaces": [
+    {
+      "binding": "QUERY_CACHE",
+      "id": "<YOUR_KV_NAMESPACE_ID>"
+    }
+  ]
+}
+```
+
+Pass the binding to `cloudflareKVCache()` when creating your Drizzle instance:
+
+```ts
+import { cloudflareKVCache } from "drizzle-orm/cache/cloudflare-kv";
+import { drizzle } from "drizzle-orm/...";
+
+const db = drizzle(env.DB, {
+  cache: cloudflareKVCache(env.QUERY_CACHE, {
+    strategy: "explicit",
+    prefix: "drizzle",
+    config: { ex: 300 }
+  })
+});
+```
+
+Set `strategy: "all"` to cache every select query. Per-query settings passed to `.$withCache()` override the default expiration:
+
+```ts
+const users = await db.select().from(usersTable).$withCache({
+  config: { ex: 600 }
+});
+```
+
+The adapter supports `ex`, `px`, `exat`, and `pxat`. Cloudflare KV requires expiration targets to be at least 60 seconds in the future, so shorter values throw an error. The Redis-specific `keepTtl` and `hexOptions` settings are not supported.
+
+<Callout type="warning">
+Workers KV is eventually consistent and is intended for read-heavy data that can tolerate stale results. Table and tag invalidation can take time to become visible in other Cloudflare locations. Use a strongly consistent store when read-after-write consistency is required.
+</Callout>
+
 ## Cache config reference
 
 Drizzle supports the following cache config options for Upstash:

--- a/src/content/docs/mysql/cache.mdx
+++ b/src/content/docs/mysql/cache.mdx
@@ -46,6 +46,51 @@ const db = drizzle(process.env.DB_URL!, {
 });
 ```
 
+### Cloudflare KV integration
+
+Cloudflare Workers applications can use a bound [Workers KV](https://developers.cloudflare.com/kv/) namespace as the query cache:
+
+```jsonc
+// wrangler.jsonc
+{
+  "kv_namespaces": [
+    {
+      "binding": "QUERY_CACHE",
+      "id": "<YOUR_KV_NAMESPACE_ID>"
+    }
+  ]
+}
+```
+
+Pass the binding to `cloudflareKVCache()` when creating your Drizzle instance:
+
+```ts
+import { cloudflareKVCache } from "drizzle-orm/cache/cloudflare-kv";
+import { drizzle } from "drizzle-orm/...";
+
+const db = drizzle(env.DB, {
+  cache: cloudflareKVCache(env.QUERY_CACHE, {
+    strategy: "explicit",
+    prefix: "drizzle",
+    config: { ex: 300 }
+  })
+});
+```
+
+Set `strategy: "all"` to cache every select query. Per-query settings passed to `.$withCache()` override the default expiration:
+
+```ts
+const users = await db.select().from(usersTable).$withCache({
+  config: { ex: 600 }
+});
+```
+
+The adapter supports `ex`, `px`, `exat`, and `pxat`. Cloudflare KV requires expiration targets to be at least 60 seconds in the future, so shorter values throw an error. The Redis-specific `keepTtl` and `hexOptions` settings are not supported.
+
+<Callout type="warning">
+Workers KV is eventually consistent and is intended for read-heavy data that can tolerate stale results. Table and tag invalidation can take time to become visible in other Cloudflare locations. Use a strongly consistent store when read-after-write consistency is required.
+</Callout>
+
 ## Cache config reference
 
 Drizzle supports the following cache config options for Upstash:

--- a/src/content/docs/pg/cache.mdx
+++ b/src/content/docs/pg/cache.mdx
@@ -46,6 +46,51 @@ const db = drizzle(process.env.DB_URL!, {
 });
 ```
 
+### Cloudflare KV integration
+
+Cloudflare Workers applications can use a bound [Workers KV](https://developers.cloudflare.com/kv/) namespace as the query cache:
+
+```jsonc
+// wrangler.jsonc
+{
+  "kv_namespaces": [
+    {
+      "binding": "QUERY_CACHE",
+      "id": "<YOUR_KV_NAMESPACE_ID>"
+    }
+  ]
+}
+```
+
+Pass the binding to `cloudflareKVCache()` when creating your Drizzle instance:
+
+```ts
+import { cloudflareKVCache } from "drizzle-orm/cache/cloudflare-kv";
+import { drizzle } from "drizzle-orm/...";
+
+const db = drizzle(env.DB, {
+  cache: cloudflareKVCache(env.QUERY_CACHE, {
+    strategy: "explicit",
+    prefix: "drizzle",
+    config: { ex: 300 }
+  })
+});
+```
+
+Set `strategy: "all"` to cache every select query. Per-query settings passed to `.$withCache()` override the default expiration:
+
+```ts
+const users = await db.select().from(usersTable).$withCache({
+  config: { ex: 600 }
+});
+```
+
+The adapter supports `ex`, `px`, `exat`, and `pxat`. Cloudflare KV requires expiration targets to be at least 60 seconds in the future, so shorter values throw an error. The Redis-specific `keepTtl` and `hexOptions` settings are not supported.
+
+<Callout type="warning">
+Workers KV is eventually consistent and is intended for read-heavy data that can tolerate stale results. Table and tag invalidation can take time to become visible in other Cloudflare locations. Use a strongly consistent store when read-after-write consistency is required.
+</Callout>
+
 ## Cache config reference
 
 Drizzle supports the following cache config options for Upstash:

--- a/src/content/docs/singlestore/cache.mdx
+++ b/src/content/docs/singlestore/cache.mdx
@@ -46,6 +46,51 @@ const db = drizzle(process.env.DB_URL!, {
 });
 ```
 
+### Cloudflare KV integration
+
+Cloudflare Workers applications can use a bound [Workers KV](https://developers.cloudflare.com/kv/) namespace as the query cache:
+
+```jsonc
+// wrangler.jsonc
+{
+  "kv_namespaces": [
+    {
+      "binding": "QUERY_CACHE",
+      "id": "<YOUR_KV_NAMESPACE_ID>"
+    }
+  ]
+}
+```
+
+Pass the binding to `cloudflareKVCache()` when creating your Drizzle instance:
+
+```ts
+import { cloudflareKVCache } from "drizzle-orm/cache/cloudflare-kv";
+import { drizzle } from "drizzle-orm/...";
+
+const db = drizzle(env.DB, {
+  cache: cloudflareKVCache(env.QUERY_CACHE, {
+    strategy: "explicit",
+    prefix: "drizzle",
+    config: { ex: 300 }
+  })
+});
+```
+
+Set `strategy: "all"` to cache every select query. Per-query settings passed to `.$withCache()` override the default expiration:
+
+```ts
+const users = await db.select().from(usersTable).$withCache({
+  config: { ex: 600 }
+});
+```
+
+The adapter supports `ex`, `px`, `exat`, and `pxat`. Cloudflare KV requires expiration targets to be at least 60 seconds in the future, so shorter values throw an error. The Redis-specific `keepTtl` and `hexOptions` settings are not supported.
+
+<Callout type="warning">
+Workers KV is eventually consistent and is intended for read-heavy data that can tolerate stale results. Table and tag invalidation can take time to become visible in other Cloudflare locations. Use a strongly consistent store when read-after-write consistency is required.
+</Callout>
+
 ## Cache config reference
 
 Drizzle supports the following cache config options for Upstash:

--- a/src/content/docs/sqlite/cache.mdx
+++ b/src/content/docs/sqlite/cache.mdx
@@ -46,6 +46,51 @@ const db = drizzle(process.env.DB_URL!, {
 });
 ```
 
+### Cloudflare KV integration
+
+Cloudflare Workers applications can use a bound [Workers KV](https://developers.cloudflare.com/kv/) namespace as the query cache:
+
+```jsonc
+// wrangler.jsonc
+{
+  "kv_namespaces": [
+    {
+      "binding": "QUERY_CACHE",
+      "id": "<YOUR_KV_NAMESPACE_ID>"
+    }
+  ]
+}
+```
+
+Pass the binding to `cloudflareKVCache()` when creating your Drizzle instance:
+
+```ts
+import { cloudflareKVCache } from "drizzle-orm/cache/cloudflare-kv";
+import { drizzle } from "drizzle-orm/...";
+
+const db = drizzle(env.DB, {
+  cache: cloudflareKVCache(env.QUERY_CACHE, {
+    strategy: "explicit",
+    prefix: "drizzle",
+    config: { ex: 300 }
+  })
+});
+```
+
+Set `strategy: "all"` to cache every select query. Per-query settings passed to `.$withCache()` override the default expiration:
+
+```ts
+const users = await db.select().from(usersTable).$withCache({
+  config: { ex: 600 }
+});
+```
+
+The adapter supports `ex`, `px`, `exat`, and `pxat`. Cloudflare KV requires expiration targets to be at least 60 seconds in the future, so shorter values throw an error. The Redis-specific `keepTtl` and `hexOptions` settings are not supported.
+
+<Callout type="warning">
+Workers KV is eventually consistent and is intended for read-heavy data that can tolerate stale results. Table and tag invalidation can take time to become visible in other Cloudflare locations. Use a strongly consistent store when read-after-write consistency is required.
+</Callout>
+
 ## Cache config reference
 
 Drizzle supports the following cache config options for Upstash:


### PR DESCRIPTION
## What changed

- document the first-party Cloudflare Workers KV query cache adapter
- add Wrangler KV binding configuration and adapter setup examples
- explain explicit and global cache strategies and per-query expiration overrides
- document supported expiration options and unsupported Redis-specific options
- call out Workers KV eventual consistency and invalidation behavior
- update every dialect-specific cache guide consistently

## Why

The ORM change for drizzle-team/drizzle-orm#5758 adds a Cloudflare-native cache option for Workers applications. The public documentation needs to explain how to bind KV, configure the adapter, and choose workloads that tolerate KV's consistency model.

## Validation

- `prettier --check` on all six modified MDX files
- `astro check` (zero errors)
