### PR TITLE
Fix broken TOC anchor on the pg relations-v1-v2 page

### DIFF
--- a/src/content/docs/pg/relations-v1-v2.mdx
+++ b/src/content/docs/pg/relations-v1-v2.mdx
@@ -25,7 +25,7 @@ Below is the table of contents. Click an item to jump to that section:
 
 - [What is working differently from v1](#what-is-working-differently-from-v1)  
 - [New features in v2](#what-is-new)  
-- [How to migrate relations definition from v1 to v2](#how-to-migrate-relations-schema-definition-from-v1-to)  
+- [How to migrate relations definition from v1 to v2](#how-to-migrate-relations-schema-definition-from-v1-to-v2)  
 - [How to migrate queries from v1 to v2](#how-to-migrate-queries-from-v1-to-v2)  
 - [Internal changes(imports, internal types, etc.)](#internal-changes)
 </Callout>


### PR DESCRIPTION
The table of contents on the Postgres **Migrating to Relational Queries version 2** page has
one entry that links to an anchor which doesn't exist, so clicking it does nothing:

```diff
- [How to migrate relations definition from v1 to v2](#how-to-migrate-relations-schema-definition-from-v1-to)
+ [How to migrate relations definition from v1 to v2](#how-to-migrate-relations-schema-definition-from-v1-to-v2)
```

The heading it should reach is `How to migrate relations schema definition from v1 to v2`.

The same page exists for four dialects with identical heading text, and the other three already
link to it correctly. `pg` was the only one missing the trailing `-v2`:

| dialect | TOC anchor |
|---|---|
| mysql | `...-from-v1-to-v2` |
| sqlite | `...-from-v1-to-v2` |
| singlestore | `...-from-v1-to-v2` |
| **pg** (before) | `...-from-v1-to` |

Checking every in-page anchor against every heading across all four files, `pg` was the only
broken one, and it is the only line changed here.

Noticed via drizzle-team/drizzle-orm#5738, which reports a broken link on this page. That issue
points at the `New features in v2` entry, which resolves to the `What is new?` heading and looks
fine. The entry directly beneath it was genuinely broken, so it is likely what was actually hit.
