### PR TITLE
docs: clarify onConflictDoNothing batch behavior

### DIFF
--- a/src/content/docs/cockroach/insert.mdx
+++ b/src/content/docs/cockroach/insert.mdx
@@ -65,7 +65,8 @@ Drizzle ORM provides simple interfaces for handling upserts and conflicts.
 
 ### On conflict do nothing
 
-`onConflictDoNothing` will cancel the insert if there's a conflict:
+`onConflictDoNothing` skips a row instead of inserting it when the row conflicts with an existing one.
+When inserting multiple rows, only the conflicting rows are skipped — the remaining rows are still inserted:
 
 ```typescript copy
 await db.insert(users)
@@ -76,6 +77,11 @@ await db.insert(users)
 await db.insert(users)
   .values({ id: 1, name: 'John' })
   .onConflictDoNothing({ target: users.id });
+
+// batch insert: the conflicting row is skipped, the others are inserted
+await db.insert(users)
+  .values([{ id: 1, name: 'John' }, { id: 2, name: 'Jane' }])
+  .onConflictDoNothing();
 ```
 
 ### On conflict do update

--- a/src/content/docs/pg/insert.mdx
+++ b/src/content/docs/pg/insert.mdx
@@ -65,7 +65,8 @@ Drizzle ORM provides simple interfaces for handling upserts and conflicts.
 
 ### On conflict do nothing
 
-`onConflictDoNothing` will cancel the insert if there's a conflict:
+`onConflictDoNothing` skips a row instead of inserting it when the row conflicts with an existing one.
+When inserting multiple rows, only the conflicting rows are skipped — the remaining rows are still inserted:
 
 ```typescript copy
 await db.insert(users)
@@ -76,6 +77,11 @@ await db.insert(users)
 await db.insert(users)
   .values({ id: 1, name: 'John' })
   .onConflictDoNothing({ target: users.id });
+
+// batch insert: the conflicting row is skipped, the others are inserted
+await db.insert(users)
+  .values([{ id: 1, name: 'John' }, { id: 2, name: 'Jane' }])
+  .onConflictDoNothing();
 ```
 
 ### On conflict do update

--- a/src/content/docs/sqlite/insert.mdx
+++ b/src/content/docs/sqlite/insert.mdx
@@ -62,7 +62,8 @@ await db.insert(users).values([{ name: 'Andrew' }, { name: 'Dan' }]);
 Drizzle ORM provides simple interfaces for handling upserts and conflicts.
 
 ### On conflict do nothing
-`onConflictDoNothing` will cancel the insert if there's a conflict:
+`onConflictDoNothing` skips a row instead of inserting it when the row conflicts with an existing one.
+When inserting multiple rows, only the conflicting rows are skipped — the remaining rows are still inserted:
 
 ```typescript copy
 await db.insert(users)
@@ -73,6 +74,11 @@ await db.insert(users)
 await db.insert(users)
   .values({ id: 1, name: 'John' })
   .onConflictDoNothing({ target: users.id });
+
+// batch insert: the conflicting row is skipped, the others are inserted
+await db.insert(users)
+  .values([{ id: 1, name: 'John' }, { id: 2, name: 'Jane' }])
+  .onConflictDoNothing();
 ```
 
 ### On conflict do update


### PR DESCRIPTION
## What

Clarifies the **On conflict do nothing** section of the insert docs for `pg`, `sqlite` and `cockroach`.

## Why

Closes [https://github.com/drizzle-team/drizzle-orm/issues/4065](https://github.com/drizzle-team/drizzle-orm/issues/4065).

The previous wording said `onConflictDoNothing` *"will cancel the insert if there's a conflict"*, which is misleading for multi-row inserts. In reality, only the conflicting rows are skipped, and the remaining rows are still inserted.

## Verification

Ran the same scenario (one existing row `id=1`, then a batch insert of `(1),(2),(3)` with `ON CONFLICT DO NOTHING`) against real databases:

| Database | Result |
|----------|--------|
| PostgreSQL 16 | `INSERT 0 2` → existing `id=1` kept, `id=2` and `id=3` inserted |
| CockroachDB | same |
| SQLite | same |

In every case only the conflicting row was skipped and the rest were inserted.

## Changes

- Reworded the description in the three dialect docs.
- Added a batch-insert example that makes the behavior explicit.