### PR TITLE
Clarify that the Latest Releases page isn't a complete release list

### DIFF
--- a/src/ui/components/LatestReleases.astro
+++ b/src/ui/components/LatestReleases.astro
@@ -21,6 +21,14 @@ const options: Intl.DateTimeFormatOptions = {
 <div class="learn__title-block">
   <div class="latest-releases_title">Latest Releases</div>
 </div>
+<div class="latest-releases__notice">
+  This page only covers releases we've written up in detail, so it's not a
+  complete or up to date list. For every release, see the
+  <a
+    href="https://github.com/drizzle-team/drizzle-orm/releases"
+    target="_blank"
+    rel="nofollow noreferrer">releases on GitHub</a>.
+</div>
 <div class="latest-updates__cards">
   {
     filteredArticles.map((update) => (
@@ -54,6 +62,23 @@ const options: Intl.DateTimeFormatOptions = {
     letter-spacing: -0.48px;
     margin-bottom: 16px;
     margin-top: 8px;
+  }
+
+  html.dark .latest-releases__notice {
+    color: #c4c5c6;
+  }
+
+  .latest-releases__notice {
+    color: #5f5f61;
+    font-size: 16px;
+    font-weight: 400;
+    line-height: 24px;
+    letter-spacing: -0.176px;
+  }
+
+  .latest-releases__notice a {
+    color: inherit;
+    text-decoration: underline;
   }
 
   .latest-updates__cards {
@@ -130,6 +155,10 @@ const options: Intl.DateTimeFormatOptions = {
       font-weight: 700;
       letter-spacing: -0.48px;
       line-height: 31.2px;
+    }
+    .latest-releases__notice {
+      font-size: 14px;
+      line-height: 21px;
     }
     .latest-updates__card_link {
       display: flex;


### PR DESCRIPTION
Addresses drizzle-team/drizzle-orm#6101.

The `/docs/latest-releases` page renders every entry under `src/content/docs/latest-releases/`, and the two newest are `drizzle-orm-v1beta2` (2025-02-12) and `drizzle-orm-v0.32.2` / `drizzle-kit-v0.23.2` (2024-08-05). Since nothing has been added since, the page reads as if the last release was over a year ago, while the actual latest release on GitHub is much more recent. As the reporter put it, it makes the project look abandoned.

This adds one line under the heading explaining that the page only covers releases with written-up notes, and linking to the GitHub releases for the full list:

> This page only covers releases we've written up in detail, so it's not a complete or up to date list. For every release, see the releases on GitHub.

The alternative the issue also mentions is backfilling the page with every release since 0.32.2, or dropping it entirely and redirecting to GitHub. Both are calls for the team to make, so I went with the smallest change that stops the page from misleading people. Happy to switch to either if you'd prefer.

Styling follows the existing conventions in the component (scoped styles, `html.dark` override, mobile size in the existing media query), and `rel="nofollow noreferrer"` for the external link to match the rest of the repo.

Verification: `pnpm install`, `npx astro check` (0 errors, 0 warnings, 11 pre-existing hints), `pnpm test` (29 passed), and checked the rendered page on `astro dev`.
