### PR TITLE
docs: fix cache extension documentation

### DIFF
--- a/src/content/docs/cockroach/cache.mdx
+++ b/src/content/docs/cockroach/cache.mdx
@@ -323,7 +323,6 @@ export class TestGlobalCache extends Cache {
 db.execute(sql`select 1`);
 ```
 
-```
 - Using cache in transactions
 ```ts
 await db.transaction(async (tx) => {

--- a/src/content/docs/mssql/cache.mdx
+++ b/src/content/docs/mssql/cache.mdx
@@ -323,7 +323,6 @@ export class TestGlobalCache extends Cache {
 db.execute(sql`select 1`);
 ```
 
-```
 - Using cache in transactions
 ```ts
 await db.transaction(async (tx) => {

--- a/src/content/docs/pg/cache.mdx
+++ b/src/content/docs/pg/cache.mdx
@@ -323,7 +323,6 @@ export class TestGlobalCache extends Cache {
 db.execute(sql`select 1`);
 ```
 
-```
 - Using cache in transactions
 ```ts
 await db.transaction(async (tx) => {


### PR DESCRIPTION
Fix the MDX formatting for the cache extension documentation.

Ran:
- `pnpm run build`
- `pnpm run preview`


Previewed the production build locally before PR.