### PR TITLE
docs: pass migrationsFolder to migrate()

### DIFF
--- a/src/content/docs/cockroach/migrations.mdx
+++ b/src/content/docs/cockroach/migrations.mdx
@@ -255,7 +255,7 @@ import { migrate } from 'drizzle-orm/cockroach/migrator';
 
 const db = drizzle(process.env.DATABASE_URL);
 
-await migrate(db);
+await migrate(db, { migrationsFolder: './drizzle' });
 ```
 ```
 ┌───────────────────────┐                  

--- a/src/content/docs/mssql/migrations.mdx
+++ b/src/content/docs/mssql/migrations.mdx
@@ -258,7 +258,7 @@ import { migrate } from 'drizzle-orm/node-mssql/migrator';
 
 const db = drizzle(process.env.DATABASE_URL);
 
-await migrate(db);
+await migrate(db, { migrationsFolder: './drizzle' });
 ```
 ```
 ┌───────────────────────┐                  

--- a/src/content/docs/mysql/migrations.mdx
+++ b/src/content/docs/mysql/migrations.mdx
@@ -254,7 +254,7 @@ import { migrate } from 'drizzle-orm/mysql2/migrator';
 
 const db = drizzle(process.env.DATABASE_URL);
 
-await migrate(db);
+await migrate(db, { migrationsFolder: './drizzle' });
 ```
 ```
 ┌───────────────────────┐                  

--- a/src/content/docs/pg/migrations.mdx
+++ b/src/content/docs/pg/migrations.mdx
@@ -251,7 +251,7 @@ import { migrate } from 'drizzle-orm/node-postgres/migrator';
 
 const db = drizzle(process.env.DATABASE_URL);
 
-await migrate(db);
+await migrate(db, { migrationsFolder: './drizzle' });
 ```
 ```
 ┌───────────────────────┐                  

--- a/src/content/docs/singlestore/migrations.mdx
+++ b/src/content/docs/singlestore/migrations.mdx
@@ -254,7 +254,7 @@ import { migrate } from 'drizzle-orm/singlestore/migrator';
 
 const db = drizzle(process.env.DATABASE_URL);
 
-await migrate(db);
+await migrate(db, { migrationsFolder: './drizzle' });
 ```
 ```
 ┌───────────────────────┐                  

--- a/src/content/docs/sqlite/migrations.mdx
+++ b/src/content/docs/sqlite/migrations.mdx
@@ -250,7 +250,7 @@ import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
 
 const db = drizzle(process.env.DATABASE_URL);
 
-await migrate(db);
+await migrate(db, { migrationsFolder: './drizzle' });
 ```
 ```
 ┌───────────────────────┐                  


### PR DESCRIPTION
Fixes https://github.com/drizzle-team/drizzle-orm-docs/issues/652

The dialect `migrations.mdx` pages called `migrate(db)` with no config. `migrate` needs `{ migrationsFolder: './drizzle' }`. Updated sqlite, pg, mysql, mssql, cockroach, and singlestore.

I used an assistant on the edit.
