### PR TITLE
docs: remove duplicated words in PostgreSQL pages

### DIFF
--- a/src/content/docs/pg/connect-nile.mdx
+++ b/src/content/docs/pg/connect-nile.mdx
@@ -117,7 +117,7 @@ export function tenantDB<T>(cb: (tx: any) => T | Promise<T>): Promise<T> {
 }
 ```
 
-And then, configure a middleware to populate the the AsyncLocalStorage and use `tenantDB` method when handling requests:
+And then, configure a middleware to populate the AsyncLocalStorage and use `tenantDB` method when handling requests:
 
 ```typescript copy filename="app.ts"
 // Middleware to set tenant context

--- a/src/content/docs/pg/rls.mdx
+++ b/src/content/docs/pg/rls.mdx
@@ -109,7 +109,7 @@ export const policy = pgPolicy("authenticated role insert policy", {
 
 If you are using drizzle-kit to manage your schema and roles, there may be situations where you want to refer to roles that are not defined in your Drizzle schema. In such cases, you may want drizzle-kit to skip managing these roles without having to define each role in your drizzle schema and marking it with `.existing()`.
 
-In these cases, you can use `entities.roles` in `drizzle.config.ts`. For a complete reference, refer to the the [drizzle.config.ts](/docs/drizzle-config-file) documentation.
+In these cases, you can use `entities.roles` in `drizzle.config.ts`. For a complete reference, refer to the [drizzle.config.ts](/docs/drizzle-config-file) documentation.
 
 By default, `drizzle-kit` does not manage roles for you, so you will need to enable this feature in `drizzle.config.ts`.
 


### PR DESCRIPTION
## Summary

Remove duplicated words in PostgreSQL documentation pages.

| File | Fix |
|------|-----|
| src/content/docs/pg/rls.mdx | "the the" → "the" |
| src/content/docs/pg/connect-nile.mdx | "the the" → "the" |

## Test plan

- [x] Verified each duplicated word was present before editing
- [x] Residual scan clean on changed files
