### PR TITLE
docs(pg): fix invalid btree access method to heap in materialized vie…

### DIFF
--- a/src/content/docs/pg/views.mdx
+++ b/src/content/docs/pg/views.mdx
@@ -169,7 +169,7 @@ export const newYorkers = pgView('new_yorkers')
 
 // materialized view
 export const newYorkers2 = pgMaterializedView('new_yorkers_2')
-  .using('btree')
+  .using('heap')
   .with({
     fillfactor: 90,
     toastTupleTarget: 0.5,
@@ -218,7 +218,7 @@ WITH
 			"sq"."homeCity" = 1
 	);
 
-CREATE MATERIALIZED VIEW "new_yorkers_2" USING "btree"
+CREATE MATERIALIZED VIEW "new_yorkers_2" USING "heap"
 WITH
 	(autovacuum_enabled = TRUE, fillfactor = 90, toast_tuple_target = 0.5) TABLESPACE custom_tablespace AS (
 		WITH


### PR DESCRIPTION
Fixes https://github.com/drizzle-team/drizzle-orm/issues/6199

    ### Summary
    The extended example for `pgMaterializedView` in `src/content/docs/pg/views.mdx` used `.using('btree')`. However, `btree` is an **Index Access Method** (`CREATE INDEX ... USING btree`), whereas the `USING` clause on `CREATE MATERIALIZED VIEW` specifies the
  **Table Access Method** (which defaults to `heap` in PostgreSQL).

    Passing `btree` causes PostgreSQL to reject the query with:
    ```
    error: access method "btree" is not of type TABLE
    ```

    ### Changes
    - Updated `.using('btree')` to `.using('heap')` in the TypeScript `pgMaterializedView` example.
    - Updated `CREATE MATERIALIZED VIEW ... USING "btree"` to `USING "heap"` in the corresponding SQL code block.

    Reference: [PostgreSQL CREATE MATERIALIZED VIEW Documentation](https://www.postgresql.org/docs/current/sql-creatematerializedview.html)
