### PR TITLE
fix: unprefix the default dialect in llms.txt links

### DIFF
--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -6,10 +6,21 @@ import {
   description,
   title,
 } from "@/data/llms";
+import { defaultDocsDialect } from "@/dialect-docs";
 
 export const GET: APIRoute = async ({ url }) => {
   // Get the URL
-  const getUrl = (path: string) => `${url.origin}/docs/${path}`;
+  // The default dialect's own docs are served unprefixed (see the
+  // `routePrefix` logic in src/pages/[...slug].astro) - a link like
+  // `${defaultDocsDialect}/select` has no route and 404s, so strip that
+  // prefix here too before building the URL.
+  const defaultDialectPrefix = `${defaultDocsDialect}/`;
+  const getUrl = (path: string) => {
+    const unprefixedPath = path.startsWith(defaultDialectPrefix)
+      ? path.slice(defaultDialectPrefix.length)
+      : path;
+    return `${url.origin}/docs/${unprefixedPath}`;
+  };
 
   // Create the LLMS
   let llms = `# ${title}\n\n> ${description}\n`;


### PR DESCRIPTION
## Summary

`[...slug].astro` serves the default dialect (`pg`) unprefixed - a route like `docs/pg/select` never exists, only `docs/select`:

```ts
const routePrefix =
  dialectId === defaultDocsDialect ? "docs" : `docs/${dialectId}`;
```

`llms.txt.ts`'s `getUrl` didn't know this and prefixed every `pg` slug with `pg/` anyway (since the meta-file slugs already carry their directory name as a prefix), so all 71 postgres links in the generated `llms.txt` 404 - the section most people probably want, since `pg` is the default.

## Fix

Strip the default dialect's own prefix in `getUrl` before building the URL, reusing `defaultDocsDialect` from `dialect-docs.ts` rather than hardcoding `"pg"`, so this stays correct if the default dialect ever changes.

## Verification

Ran the dev server and diffed `/llms.txt` before/after:

```
$ curl -so /dev/null -w "%{http_code}\n" http://localhost:4321/docs/select
200
$ curl -so /dev/null -w "%{http_code}\n" http://localhost:4321/docs/pg/select
404
$ curl -so /dev/null -w "%{http_code}\n" http://localhost:4321/docs/mysql/select
200
$ grep -c "/docs/pg/" llms.txt   # before: 71, after:
0
```

All other dialects are untouched (still correctly prefixed). Full test suite (`pnpm test`, 29 tests) passes.

Fixes #705

🤖 Generated with [Claude Code](https://claude.com/claude-code)